### PR TITLE
LVFM-328: bssrf section address and size read from elf file

### DIFF
--- a/speculos.py
+++ b/speculos.py
@@ -50,7 +50,7 @@ def get_elf_infos(app_path):
             sys.exit(1)
         estack = sym_estack[0]['st_value']
         supp_ram = elf.get_section_by_name('.rfbss')
-        ram_addr, ram_size = (supp_ram['sh_addr'], supp_ram.data_size) if supp_ram is not None else (0, 0)
+        ram_addr, ram_size = (supp_ram['sh_addr'], supp_ram['sh_size']) if supp_ram is not None else (0, 0)
     stack_size = estack - stack
     return sh_offset, sh_size, stack, stack_size, ram_addr, ram_size
 

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -460,7 +460,13 @@ static void *load_app(char *name, hw_platform_t plat)
         warn("mmap extra RAM page");
         goto error;
       }
-      fprintf(stderr, "[*] platform = %s, using extra RAM page @%p (size: %u bytes)\n", platform_string(plat), extra_addr, extra_size);
+      fprintf(stderr, "[*] platform = %s, using extra RAM page [@=%p, size=%u bytes]", platform_string(plat), extra_addr, extra_size);
+      if (extra_addr != extra_rampage_addr || extra_size != extra_rampage_size) {
+        fprintf(stderr, ", realigned from [@=%p, size=%u bytes]\n", extra_rampage_addr, extra_rampage_size);
+      }
+      else {
+        fprintf(stderr, "\n");
+      }
     }
     else  {
       fprintf(stderr, "[*] platform = %s, not using extra RAM\n", platform_string(plat));


### PR DESCRIPTION
Additional ram page address & size now read from ELF file. If provided on the CLI by the user, parameters -q & -r will supersede the values from the ELF file. 