### PR TITLE
Connect/Disconnect on each request

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "openssl"]
-	path = openssl
-	url = https://github.com/openssl/openssl.git
-[submodule "tests/cmocka"]
-	path = tests/cmocka
-	url = git://git.cryptomilk.org/projects/cmocka.git

--- a/tools/ledger-live-http-proxy.py
+++ b/tools/ledger-live-http-proxy.py
@@ -44,11 +44,11 @@ class SimpleHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         apdu = json.loads(body)
         apdu = binascii.unhexlify(apdu['apduHex'])
 
-        if args.verbose:
-            print('<', binascii.hexlify(apdu))
-
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect(('127.0.0.1', int(args.port)))
+
+            if args.verbose:
+                print('<', binascii.hexlify(apdu))
 
             # forward the APDU to the APDU server
             apdu = len(apdu).to_bytes(4, 'big') + apdu


### PR DESCRIPTION
The purpose is to avoid restarting the proxy each time a qemu session is closed or restarted.

(also fixes a small problem with subrepos that were not committed correctly)