### PR TITLE
Add new entrypoint for weblue using websocket redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 .cache/
 .idea/
+.DS_Store
 __pycache__/
 apps/*vault*
 build/

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 pyelftools = "*"
 mnemonic = "*"
 construct = "*"
+websockify = "*"  # Used by weblue to forward apdu and vnc port over wss
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d36248c86cc6ab0347863eef02db74420917e062b9f4ff006d0c6fb676e6b664"
+            "sha256": "5814ac3e555e431d7163262e75a3ed0a6fbc105a6d24eacdf6909125917557db"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,32 @@
             "index": "pypi",
             "version": "==0.19"
         },
+        "numpy": {
+            "hashes": [
+                "sha256:1786a08236f2c92ae0e70423c45e1e62788ed33028f94ca99c4df03f5be6b3c6",
+                "sha256:17aa7a81fe7599a10f2b7d95856dc5cf84a4eefa45bc96123cbbc3ebc568994e",
+                "sha256:20b26aaa5b3da029942cdcce719b363dbe58696ad182aff0e5dcb1687ec946dc",
+                "sha256:2d75908ab3ced4223ccba595b48e538afa5ecc37405923d1fea6906d7c3a50bc",
+                "sha256:39d2c685af15d3ce682c99ce5925cc66efc824652e10990d2462dfe9b8918c6a",
+                "sha256:56bc8ded6fcd9adea90f65377438f9fea8c05fcf7c5ba766bef258d0da1554aa",
+                "sha256:590355aeade1a2eaba17617c19edccb7db8d78760175256e3cf94590a1a964f3",
+                "sha256:70a840a26f4e61defa7bdf811d7498a284ced303dfbc35acb7be12a39b2aa121",
+                "sha256:77c3bfe65d8560487052ad55c6998a04b654c2fbc36d546aef2b2e511e760971",
+                "sha256:9537eecf179f566fd1c160a2e912ca0b8e02d773af0a7a1120ad4f7507cd0d26",
+                "sha256:9acdf933c1fd263c513a2df3dceecea6f3ff4419d80bf238510976bf9bcb26cd",
+                "sha256:ae0975f42ab1f28364dcda3dde3cf6c1ddab3e1d4b2909da0cb0191fa9ca0480",
+                "sha256:b3af02ecc999c8003e538e60c89a2b37646b39b688d4e44d7373e11c2debabec",
+                "sha256:b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77",
+                "sha256:b765ed3930b92812aa698a455847141869ef755a87e099fddd4ccf9d81fffb57",
+                "sha256:c98c5ffd7d41611407a1103ae11c8b634ad6a43606eca3e2a5a269e5d6e8eb07",
+                "sha256:cf7eb6b1025d3e169989416b1adcd676624c2dbed9e3bcb7137f51bfc8cc2572",
+                "sha256:d92350c22b150c1cae7ebb0ee8b5670cc84848f6359cf6b5d8f86617098a9b73",
+                "sha256:e422c3152921cece8b6a2fb6b0b4d73b6579bd20ae075e7d15143e711f3ca2ca",
+                "sha256:e840f552a509e3380b0f0ec977e8124d0dc34dc0e68289ca28f4d7c1d0d79474",
+                "sha256:f3d0a94ad151870978fb93538e95411c83899c9dc63e6fb65542f769568ecfa5"
+            ],
+            "version": "==1.18.1"
+        },
         "pyelftools": {
             "hashes": [
                 "sha256:86ac6cee19f6c945e8dedf78c6ee74f1112bd14da5a658d8c9d4103aed5756a2",
@@ -38,6 +64,13 @@
             ],
             "index": "pypi",
             "version": "==0.26"
+        },
+        "websockify": {
+            "hashes": [
+                "sha256:c35b5b79ebc517d3b784dacfb993be413a93cda5222c6f382443ce29c1a6cada"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
         }
     },
     "develop": {}

--- a/scripts/weblue_entrypoint.sh
+++ b/scripts/weblue_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+APDU_PORT=40000
+VNC_PORT=41000
+
+websockify 50000 localhost:${APDU_PORT} --cert ./certificate/ws.pem &  # for apdu
+websockify 60000 localhost:${VNC_PORT} --cert ./certificate/ws.pem &  # for vnc
+exec ./speculos.py ${DEBUG_MODE:-} -m ${DEVICE_MODEL} --sdk ${SDK_VERSION} --seed "${DEVICE_SEED}" --rampage ${RAMPAGE} --display headless --vnc-port ${VNC_PORT} --apdu-port ${APDU_PORT} ./apps/${APP_FILE}


### PR DESCRIPTION
WeBlue requires a different docker entrypoint to run speculos, expecting a few env variables to customize the run.
This new entrypoint `scripts/weblue_entrypoint.sh` is kept separate from the "normal" run of speculos, so we are not disturbing existing users with our special flow.

In addition, it handles APDUs and VNC over websockets, so I am adding back websockify to the python dependencies.