### PR TITLE
Do not require C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(Speculos)
+project(Speculos C)
 
 include(ExternalProject)
 


### PR DESCRIPTION
Specify project language, to avoid cmake trying to find C++ compiler.