### PR TITLE
Allow CORS in ledger-live-http-proxy

### DIFF
--- a/tools/ledger-live-http-proxy.py
+++ b/tools/ledger-live-http-proxy.py
@@ -35,6 +35,14 @@ class SimpleHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
 
     def do_GET(self):
         self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", self.headers["Origin"])
+        self.send_header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST")
         self.end_headers()
 
     def do_POST(self):
@@ -70,6 +78,7 @@ class SimpleHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Content-Length', len(data))
         self.send_header('Content-Type', 'application/json')
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(data)
 


### PR DESCRIPTION
This makes it possible to access this server from web page running on different origin (host / port).