### PR TITLE
openssl update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,8 @@ else()
 
   ExternalProject_Add(
     openssl
-    URL https://www.openssl.org/source/openssl-1.1.1d.tar.gz
-    URL_HASH SHA256=1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
+    URL https://www.openssl.org/source/openssl-1.1.1f.tar.gz
+    URL_HASH SHA256=186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35
     CONFIGURE_COMMAND ./Configure --cross-compile-prefix=arm-linux-gnueabihf- no-asm no-threads no-shared no-sock linux-armv4 --prefix=${INSTALL_DIR}
     BUILD_COMMAND make CFLAGS=-mthumb
     INSTALL_COMMAND make install_sw

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -22,12 +22,12 @@ RUN pip3 install construct mnemonic pycrypto pyelftools pbkdf2 pytest
 
 # Create SHA256SUMS
 RUN \
-  echo 1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2 openssl-1.1.1d.tar.gz >> SHA256SUMS && \
+  echo 186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35 openssl-1.1.1f.tar.gz >> SHA256SUMS && \
   echo f0ccd8242d55e2fd74b16ba518359151f6f8383ff8aef4976e48393f77bba8b6 cmocka-1.1.5.tar.xz >> SHA256SUMS
 
 # Download dependencies
 RUN \
-  wget https://www.openssl.org/source/openssl-1.1.1d.tar.gz && \
+  wget https://www.openssl.org/source/openssl-1.1.1f.tar.gz && \
   wget https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz
 
 # Verify dependencies integrity
@@ -36,8 +36,8 @@ RUN sha256sum --check SHA256SUMS
 # Build dependencies
 RUN mkdir install
 
-RUN tar xf openssl-1.1.1d.tar.gz
-RUN cd openssl-1.1.1d && ./Configure --cross-compile-prefix=arm-linux-gnueabihf- no-asm no-threads no-shared no-sock linux-armv4 --prefix=/install && make -j CFLAGS=-mthumb && make install_sw
+RUN tar xf openssl-1.1.1f.tar.gz
+RUN cd openssl-1.1.1f && ./Configure --cross-compile-prefix=arm-linux-gnueabihf- no-asm no-threads no-shared no-sock linux-armv4 --prefix=/install && make -j CFLAGS=-mthumb && make install_sw
 
 RUN mkdir cmocka
 RUN tar xf cmocka-1.1.5.tar.xz
@@ -48,8 +48,8 @@ RUN rm -rf \
   cmocka/ \
   cmocka-1.1.5/ \
   cmocka-1.1.5.tar.xz \
-  openssl-1.1.1d/ \
-  openssl-1.1.1d.tar.gz \
+  openssl-1.1.1f/ \
+  openssl-1.1.1f.tar.gz \
   SHA256SUMS
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
`openssl-1.1.1d` is no more available at https://www.openssl.org/source/openssl-1.1.1d.tar.gz, the building process was failing:


> -- Downloading...
>    dst='/speculos/build/openssl-prefix/src/openssl-1.1.1d.tar.gz'
>    timeout='none'
> -- Using src='https://www.openssl.org/source/openssl-1.1.1d.tar.gz'
> -- Retrying...
> -- Using src='https://www.openssl.org/source/openssl-1.1.1d.tar.gz'
> -- Retry after 5 seconds (attempt #2) ...
> -- Using src='https://www.openssl.org/source/openssl-1.1.1d.tar.gz'
> -- Retry after 5 seconds (attempt #3) ...


So I updated it to the latest version `openssl-1.1.1f`.