### PR TITLE
pyQt segfault bugfix

### DIFF
--- a/mcu/screen.py
+++ b/mcu/screen.py
@@ -194,7 +194,7 @@ class App(QMainWindow):
 class QtScreen:
     def __init__(self, apdu, seph, button_tcp=None, finger_tcp=None, color='MATTE_BLACK', model='nanos', ontop=False, rendering=RENDER_METHOD.FLUSHED, vnc=None, pixel_size=2, **_):
         self.app = QApplication(sys.argv)
-        App(apdu, seph, button_tcp, finger_tcp, color, model, ontop, rendering, vnc, pixel_size)
+        self.app_widget = App(apdu, seph, button_tcp, finger_tcp, color, model, ontop, rendering, vnc, pixel_size)
 
     def run(self):
         self.app.exec_()


### PR DESCRIPTION
Fixes segfaults happening in some (rare?) cases with pyQt.

```
Traceback (most recent call last):
  File "/media/veracrypt1/speculos/mcu/screen.py", line 34, in paintEvent
    self.qp = qp = QPainter(self)
RuntimeError: wrapped C/C++ object of type PaintWidget has been deleted
```