### PR TITLE
fix BOLOS_UX_OK with SDK 1.6

### DIFF
--- a/src/emu_default.c
+++ b/src/emu_default.c
@@ -6,33 +6,10 @@
 
 #define PAGE_SIZE	4096
 
-#define BOLOS_UX_OK     0xB0105011
-#define BOLOS_UX_CANCEL 0xB0105022
-#define BOLOS_UX_ERROR  0xB0105033
-#define BOLOS_UX_IGNORE 0xB0105044
-#define BOLOS_UX_REDRAW	0xB0105055
-#define BOLOS_UX_CONTINUE 0
-
-/* TODO */
-unsigned long sys_os_ux(bolos_ux_params_t *UNUSED(params))
-{
-  return BOLOS_UX_OK;
-}
-
-unsigned long sys_os_global_pin_is_validated(void)
-{
-  return BOLOS_UX_OK;
-}
-
 unsigned long sys_os_global_pin_invalidate(void)
 {
   /* return void actually */
   return 0;
-}
-
-unsigned long sys_os_perso_isonboarded(void)
-{
-  return BOLOS_UX_OK;
 }
 
 /*

--- a/src/emu_os_1.5.c
+++ b/src/emu_os_1.5.c
@@ -1,7 +1,25 @@
 #include "emulate.h"
 
+#define BOLOS_UX_OK     0xB0105011
+
+/* TODO */
+unsigned long sys_os_ux_1_5(bolos_ux_params_t *UNUSED(params))
+{
+  return BOLOS_UX_OK;
+}
+
+unsigned long sys_os_global_pin_is_validated_1_5(void)
+{
+  return BOLOS_UX_OK;
+}
+
+unsigned long sys_os_perso_isonboarded_1_5(void)
+{
+  return BOLOS_UX_OK;
+}
+
 unsigned long sys_os_sched_last_status_1_5(void)
 {
   // TODO ?
-  return 0xB0105011; /* XXX */
+  return BOLOS_UX_OK; /* XXX */
 }

--- a/src/emu_os_1.6.c
+++ b/src/emu_os_1.6.c
@@ -1,7 +1,25 @@
 #include "emulate.h"
 
+#define BOLOS_UX_OK     0xAA
+
+/* TODO */
+unsigned long sys_os_ux_1_6(bolos_ux_params_t *UNUSED(params))
+{
+  return BOLOS_UX_OK;
+}
+
+unsigned long sys_os_global_pin_is_validated_1_6(void)
+{
+  return BOLOS_UX_OK;
+}
+
+unsigned long sys_os_perso_isonboarded_1_6(void)
+{
+  return BOLOS_UX_OK;
+}
+
 unsigned long sys_os_sched_last_status_1_6(unsigned int UNUSED(task_idx))
 {
   // TODO ?
-  return 0xAA; // >1.6 : status is just a char
+  return BOLOS_UX_OK; // >1.6 : status is just a char
 }

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -333,12 +333,8 @@ int emulate_common(unsigned long syscall, unsigned long *parameters, unsigned lo
 
   SYSCALL0(os_flags);
 
-  SYSCALL0(os_global_pin_invalidate);
-
   SYSCALL1(os_lib_throw, "(0x%x)",
            unsigned int, exception);
-
-  SYSCALL0(os_perso_isonboarded);
 
   SYSCALL5(os_perso_derive_node_bip32, "(0x%x, %p, %u, %p, %p)",
            cx_curve_t,       curve,
@@ -352,8 +348,6 @@ int emulate_common(unsigned long syscall, unsigned long *parameters, unsigned lo
            unsigned int, tag,
            uint8_t *,    buffer,
            size_t,       length);
-
-  SYSCALL1(os_ux, "(%p)", bolos_ux_params_t *, params);
 
   SYSCALL0(try_context_get);
 

--- a/src/emulate.h
+++ b/src/emulate.h
@@ -58,16 +58,19 @@ unsigned long sys_os_version(uint8_t *buffer, unsigned int len);
 unsigned long sys_os_seph_version(uint8_t *buffer, size_t len);
 unsigned long sys_os_lib_call(unsigned long *parameters);
 unsigned long sys_os_lib_end(void);
-unsigned long sys_os_global_pin_is_validated(void);
+unsigned long sys_os_global_pin_is_validated_1_5(void);
+unsigned long sys_os_global_pin_is_validated_1_6(void);
 unsigned long sys_os_global_pin_invalidate(void);
-unsigned long sys_os_perso_isonboarded(void);
+unsigned long sys_os_perso_isonboarded_1_5(void);
+unsigned long sys_os_perso_isonboarded_1_6(void);
 unsigned long sys_os_flags(void);
 int sys_nvm_write(void *dst_addr, void* src_addr, size_t src_len);
 unsigned long sys_os_perso_derive_node_bip32(cx_curve_t curve, const uint32_t *path, size_t length, uint8_t *private_key, uint8_t* chain);
 unsigned long sys_os_perso_derive_node_with_seed_key(unsigned int mode, cx_curve_t curve, const unsigned int *path, unsigned int pathLength,
     unsigned char *privateKey, unsigned char *chain, unsigned char *seed_key, unsigned int seed_key_length);
 unsigned long sys_os_registry_get_current_app_tag(unsigned int tag, uint8_t *buffer, size_t length);
-unsigned long sys_os_ux(bolos_ux_params_t *params);
+unsigned long sys_os_ux_1_5(bolos_ux_params_t *params);
+unsigned long sys_os_ux_1_6(bolos_ux_params_t *params);
 
 unsigned long sys_cx_hash(cx_hash_t *hash, int mode, const uint8_t *in, size_t len, uint8_t *out, size_t out_len);
 unsigned long sys_cx_rng(uint8_t *buffer, unsigned int length);

--- a/src/emulate_1.5.c
+++ b/src/emulate_1.5.c
@@ -33,9 +33,11 @@ int emulate_1_5(unsigned long syscall, unsigned long *parameters, unsigned long 
            uint8_t *, buffer,
            uint16_t,  length);
 
+  SYSCALL0i(os_perso_isonboarded, os_perso_isonboarded_1_5);
+
   SYSCALL0i(os_sched_last_status, os_sched_last_status_1_5);
 
-  SYSCALL0(os_global_pin_is_validated);
+  SYSCALL0i(os_global_pin_is_validated, os_global_pin_is_validated_1_5);
 
   SYSCALL1(os_sched_exit, "(%u)", unsigned int, code);
 
@@ -46,6 +48,8 @@ int emulate_1_5(unsigned long syscall, unsigned long *parameters, unsigned long 
   SYSCALL2(os_seph_version, "(%p %u)",
            uint8_t *, buffer,
            size_t,    length);
+
+  SYSCALL1i(os_ux, "(%p)", bolos_ux_params_t *, params, os_ux_1_5);
 
   SYSCALL0(reset);
 

--- a/src/emulate_1.6.c
+++ b/src/emulate_1.6.c
@@ -37,9 +37,9 @@ int emulate_1_6(unsigned long syscall, unsigned long *parameters, unsigned long 
 
   SYSCALL0(os_flags);
 
-  SYSCALL0(os_perso_isonboarded);
+  SYSCALL0i(os_perso_isonboarded, os_perso_isonboarded_1_6);
 
-  SYSCALL0(os_global_pin_is_validated);
+  SYSCALL0i(os_global_pin_is_validated, os_global_pin_is_validated_1_6);
 
   SYSCALL3(os_registry_get_current_app_tag, "(0x%x, %p, %u)",
            unsigned int, tag,
@@ -67,6 +67,8 @@ int emulate_1_6(unsigned long syscall, unsigned long *parameters, unsigned long 
            unsigned char *,      chain,
            unsigned char *,      seed_key,
            unsigned int,         seed_key_length);
+
+  SYSCALL1i(os_ux, "(%p)", bolos_ux_params_t *, params, os_ux_1_6);
 
   default:
     retid = emulate_common(syscall, parameters, ret, verbose);

--- a/src/emulate_blue_2.2.5.c
+++ b/src/emulate_blue_2.2.5.c
@@ -25,7 +25,7 @@ int emulate_blue_2_2_5(unsigned long syscall, unsigned long *parameters, unsigne
 
   SYSCALL0(os_flags);
 
-  SYSCALL0(os_perso_isonboarded);
+  SYSCALL0i(os_perso_isonboarded, os_perso_isonboarded_1_5);
 
   SYSCALL1i(os_sched_last_status, "(%u)", unsigned int, task_idx, os_sched_last_status_1_6);
 
@@ -44,7 +44,9 @@ int emulate_blue_2_2_5(unsigned long syscall, unsigned long *parameters, unsigne
 
   SYSCALL1(os_sched_exit, "(%u)", unsigned int, code);
 
-  SYSCALL0(os_global_pin_is_validated);
+  SYSCALL0i(os_global_pin_is_validated, os_global_pin_is_validated_1_5);
+
+  SYSCALL1i(os_ux, "(%p)", bolos_ux_params_t *, params, os_ux_1_6);
 
   default:
     retid = emulate_common(syscall, parameters, ret, verbose);


### PR DESCRIPTION
A few syscalls return BOLOS_UX_OK whose value changed over time:

- SDK 1.5: 0xB0105011
- SDK 1.6: 0xAA