### PR TITLE
enable `cx_sha512_init()` syscall

### DIFF
--- a/src/cx_hash.h
+++ b/src/cx_hash.h
@@ -249,6 +249,7 @@ int sys_cx_hash_sha256(const unsigned char *in, unsigned int len,
 #define sys_cx_blake2b_init   cx_blake2b_init
 #define sys_cx_blake2b_init2  cx_blake2b_init2
 #define sys_cx_sha256_init    cx_sha256_init
+#define sys_cx_sha512_init    cx_sha512_init
 #define sys_cx_ripemd160_init cx_ripemd160_init
 #define sys_cx_keccak_init    cx_keccak_init
 #define sys_cx_sha3_init      cx_sha3_init

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -293,6 +293,8 @@ int emulate_common(unsigned long syscall, unsigned long *parameters, unsigned lo
 
   SYSCALL1(cx_sha256_init, "(%p)", cx_sha256_t *, hash);
 
+  SYSCALL1(cx_sha512_init, "(%p)", cx_sha512_t *, hash);
+
   SYSCALL2(cx_sha3_init, "(%p, %u)",
           cx_sha3_t *, hash,
           unsigned int, size);


### PR DESCRIPTION
Duplicated existing `cx_sha256_init()` syscall.