### PR TITLE
Add code coverage instrumentation using option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,30 @@ option(WITH_VNC "Support for VNC" OFF)
 add_compile_options(-mthumb -W -Wall -fPIC)
 add_definitions(-DOS_LITTLE_ENDIAN -DNATIVE_64BITS)
 
+option(
+  CODE_COVERAGE
+  "Builds targets with code coverage instrumentation. (Requires GCC or Clang)"
+  OFF
+)
+if (CODE_COVERAGE)
+  # Always disable optimisations and build with debug symbols, when building for code coverage
+  add_compile_options(-O0 -g)
+  add_link_options(-g)
+  if (CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+    # Options for clang
+    message(STATUS "Building with clang code coverage...")
+    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+  elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+    # Options for gcc
+    message(STATUS "Building with gcc code coverage...")
+    add_compile_options(--coverage -fprofile-arcs -ftest-coverage)
+    add_link_options(--coverage -fprofile-arcs -ftest-coverage)
+  else()
+    message(FATAL_ERROR "Unable to identify the compiler! Aborting...")
+  endif()
+endif()
+
 include_directories(sdk src)
 
 if (PRECOMPILED_DEPENDENCIES_DIR)

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -19,3 +19,24 @@ specific test verbose:
 ```console
 make -C build/ test ARGS='-V -R test_bip32'
 ```
+
+### Code coverage
+
+In order to build with code coverage instrumentation, the CMake configuration supports `CODE_COVERAGE` macro:
+```console
+cmake -Bbuild -H. -DCODE_COVERAGE=ON
+make -C build/ clean
+make -C build/ all
+```
+
+When using gcc to build the project (which is by default), this enables instrumentation with gcov: these commands created `.gcno` files in `build/`.
+
+[lcov](http://ltp.sourceforge.net/coverage/lcov.php) can be used to collect code coverage and generates a HTML report in `coverage/`:
+```console
+lcov -d . --zerocounters
+lcov -d . --capture --initial -o coverage.base
+make -C build/ test
+lcov -d . --rc lcov_branch_coverage=1 --capture -o coverage.capture
+lcov -d . --add-tracefile coverage.base --add-tracefile coverage.capture -o coverage.total
+genhtml coverage.total -o coverage
+```


### PR DESCRIPTION
Using code coverage makes is easier to find out what is tested by running `make -C build test`.

After this PR, it is possible to integrate Speculos CI with https://codecov.io in order to compare the code coverage of tests for each PR. I have done this in https://codecov.io/gh/niooss-ledger/speculos and I will clean up my changes and submit them, once this PR is reviewed and merged.