### PR TITLE
Push code coverage to codecov.io, in GitHub actions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -46,3 +46,19 @@ jobs:
         password: ${{ secrets.dockerhub_password }}
         tag_with_sha: true
         tags: latest
+
+    - name: Rebuild with code coverage instrumentation
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+      run: |
+        cmake -Bbuild -H. -DPRECOMPILED_DEPENDENCIES_DIR=/install -DWITH_VNC=1 -DCODE_COVERAGE=ON
+        make -C build clean
+        make -C build
+        make -C build test
+        pytest
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        name: codecov-speculos
+        fail_ci_if_error: true


### PR DESCRIPTION
This produces nice coverage reports such as https://codecov.io/gh/niooss-ledger/speculos

NB. This Pull Request requires `curl` to be available in `ledgerhq/speculos-builder` Docker image, so https://github.com/LedgerHQ/speculos/pull/79 has to be reviewed and merged before.