### PR TITLE
Test syscalls cx_hash_sha256 and cx_hash_sha512

### DIFF
--- a/src/cx_sha256.c
+++ b/src/cx_sha256.c
@@ -249,5 +249,5 @@ int sys_cx_hash_sha256(const unsigned char *in, unsigned int len,
   cx_sha256_init(&G_cx.sha256);
   cx_sha256_update(&G_cx.sha256, in, len);
   cx_sha256_final(&G_cx.sha256, out);
-  return 0;
+  return CX_SHA256_SIZE;
 }

--- a/tests/syscalls/nist_cavp.h
+++ b/tests/syscalls/nist_cavp.h
@@ -10,3 +10,9 @@ void test_cavp_monte(cx_md_t md_type, uint8_t *initial_seed, const uint8_t *expe
 void test_cavp_short_msg_with_size(const char *filename, cx_md_t md_type, size_t digest_size);
 void test_cavp_long_msg_with_size(const char *filename, cx_md_t md_type, size_t digest_size);
 void test_cavp_monte_with_size(cx_md_t md_type, uint8_t *initial_seed, const uint8_t *expected_seed, size_t digest_size);
+
+/* Test with a single hash function, that combines init, update and final */
+typedef int (*single_hash_t)(const unsigned char *in, unsigned int len,
+                             unsigned char *out, unsigned int out_len);
+void test_cavp_short_msg_with_single(const char *filename, single_hash_t hash,
+                                     size_t digest_size);

--- a/tests/syscalls/test_sha2.c
+++ b/tests/syscalls/test_sha2.c
@@ -17,6 +17,11 @@ void test_sha256_short_msg(void **state __attribute__((unused))) {
   test_cavp_short_msg(TESTS_PATH "cavp/sha256_short_msg.data", CX_SHA256);
 }
 
+void test_sha256_short_msg_single(void **state __attribute__((unused))) {
+  test_cavp_short_msg_with_single(TESTS_PATH "cavp/sha256_short_msg.data",
+                                  sys_cx_hash_sha256, 32);
+}
+
 void test_sha256_long_msg(void **state __attribute__((unused))) {
   test_cavp_long_msg(TESTS_PATH "cavp/sha256_long_msg.data", CX_SHA256);
 }
@@ -84,6 +89,11 @@ void test_sha512_short_msg(void **state __attribute__((unused))) {
   test_cavp_short_msg(TESTS_PATH "cavp/sha512_short_msg.data", CX_SHA512);
 }
 
+void test_sha512_short_msg_single(void **state __attribute__((unused))) {
+  test_cavp_short_msg_with_single(TESTS_PATH "cavp/sha512_short_msg.data",
+                                  sys_cx_hash_sha512, 64);
+}
+
 void test_sha512_long_msg(void **state __attribute__((unused))) {
   test_cavp_long_msg(TESTS_PATH "cavp/sha512_long_msg.data", CX_SHA512);
 }
@@ -112,12 +122,14 @@ int main(void) {
                                      cmocka_unit_test(test_sha224_long_msg),
                                      cmocka_unit_test(test_sha224_monte),
                                      cmocka_unit_test(test_sha256_short_msg),
+                                     cmocka_unit_test(test_sha256_short_msg_single),
                                      cmocka_unit_test(test_sha256_long_msg),
                                      cmocka_unit_test(test_sha256_monte),
                                      cmocka_unit_test(test_sha384_short_msg),
                                      cmocka_unit_test(test_sha384_long_msg),
                                      cmocka_unit_test(test_sha384_monte),
                                      cmocka_unit_test(test_sha512_short_msg),
+                                     cmocka_unit_test(test_sha512_short_msg_single),
                                      cmocka_unit_test(test_sha512_long_msg),
                                      cmocka_unit_test(test_sha512_monte)};
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
The syscalls `cx_hash_sha256` and `cx_hash_sha512` perform `hash_init`, `hash_update` and `hash_final` in a single syscall, and return the size of the digest. Test their implementations.