### PR TITLE
Remove unused functions from Blake2b implementation

### DIFF
--- a/src/cx_blake2b.c
+++ b/src/cx_blake2b.c
@@ -155,21 +155,6 @@ int cx_blake2b(cx_hash_t  *hash, int mode,
   #define BLAKE2_INLINE inline
 #endif
 
-static BLAKE2_INLINE uint32_t load32( const void *src )
-{
-#if defined(NATIVE_LITTLE_ENDIAN)
-  uint32_t w;
-  memcpy(&w, src, sizeof w);
-  return w;
-#else
-  const uint8_t *p = ( const uint8_t * )src;
-  return (( uint32_t )( p[0] ) <<  0) |
-         (( uint32_t )( p[1] ) <<  8) |
-         (( uint32_t )( p[2] ) << 16) |
-         (( uint32_t )( p[3] ) << 24) ;
-#endif
-}
-
 static BLAKE2_INLINE uint64_t load64( const void *src )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
@@ -186,30 +171,6 @@ static BLAKE2_INLINE uint64_t load64( const void *src )
          (( uint64_t )( p[5] ) << 40) |
          (( uint64_t )( p[6] ) << 48) |
          (( uint64_t )( p[7] ) << 56) ;
-#endif
-}
-
-static BLAKE2_INLINE uint16_t load16( const void *src )
-{
-#if defined(NATIVE_LITTLE_ENDIAN)
-  uint16_t w;
-  memcpy(&w, src, sizeof w);
-  return w;
-#else
-  const uint8_t *p = ( const uint8_t * )src;
-  return (( uint16_t )( p[0] ) <<  0) |
-         (( uint16_t )( p[1] ) <<  8) ;
-#endif
-}
-
-static BLAKE2_INLINE void store16( void *dst, uint16_t w )
-{
-#if defined(NATIVE_LITTLE_ENDIAN)
-  memcpy(dst, &w, sizeof w);
-#else
-  uint8_t *p = ( uint8_t * )dst;
-  *p++ = ( uint8_t )w; w >>= 8;
-  *p++ = ( uint8_t )w;
 #endif
 }
 
@@ -241,33 +202,6 @@ static BLAKE2_INLINE void store64( void *dst, uint64_t w )
   p[6] = (uint8_t)(w >> 48);
   p[7] = (uint8_t)(w >> 56);
 #endif
-}
-
-static BLAKE2_INLINE uint64_t load48( const void *src )
-{
-  const uint8_t *p = ( const uint8_t * )src;
-  return (( uint64_t )( p[0] ) <<  0) |
-         (( uint64_t )( p[1] ) <<  8) |
-         (( uint64_t )( p[2] ) << 16) |
-         (( uint64_t )( p[3] ) << 24) |
-         (( uint64_t )( p[4] ) << 32) |
-         (( uint64_t )( p[5] ) << 40) ;
-}
-
-static BLAKE2_INLINE void store48( void *dst, uint64_t w )
-{
-  uint8_t *p = ( uint8_t * )dst;
-  p[0] = (uint8_t)(w >>  0);
-  p[1] = (uint8_t)(w >>  8);
-  p[2] = (uint8_t)(w >> 16);
-  p[3] = (uint8_t)(w >> 24);
-  p[4] = (uint8_t)(w >> 32);
-  p[5] = (uint8_t)(w >> 40);
-}
-
-static BLAKE2_INLINE uint32_t rotr32( const uint32_t w, const unsigned c )
-{
-  return ( w >> c ) | ( w << ( 32 - c ) );
 }
 
 static BLAKE2_INLINE uint64_t rotr64( const uint64_t w, const unsigned c )


### PR DESCRIPTION
clang reports the following warnings when building speculos:

    [  2%] Building C object src/CMakeFiles/emu.dir/cx_blake2b.c.o
    /code/src/cx_blake2b.c:158:31: warning: unused function 'load32' [-Wunused-function]
    static BLAKE2_INLINE uint32_t load32( const void *src )
                                  ^
    /code/src/cx_blake2b.c:192:31: warning: unused function 'load16' [-Wunused-function]
    static BLAKE2_INLINE uint16_t load16( const void *src )
                                  ^
    /code/src/cx_blake2b.c:205:27: warning: unused function 'store16' [-Wunused-function]
    static BLAKE2_INLINE void store16( void *dst, uint16_t w )
                              ^
    /code/src/cx_blake2b.c:246:31: warning: unused function 'load48' [-Wunused-function]
    static BLAKE2_INLINE uint64_t load48( const void *src )
                                  ^
    /code/src/cx_blake2b.c:257:27: warning: unused function 'store48' [-Wunused-function]
    static BLAKE2_INLINE void store48( void *dst, uint64_t w )
                              ^
    /code/src/cx_blake2b.c:268:31: warning: unused function 'rotr32' [-Wunused-function]
    static BLAKE2_INLINE uint32_t rotr32( const uint32_t w, const unsigned c )
                                  ^
    6 warnings generated.