### PR TITLE
Make the code coverage deterministic

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -50,6 +50,7 @@ jobs:
     - name: Rebuild with code coverage instrumentation
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
+        RNG_SEED: 0
       run: |
         cmake -Bbuild -H. -DPRECOMPILED_DEPENDENCIES_DIR=/install -DWITH_VNC=1 -DCODE_COVERAGE=ON
         make -C build clean

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -35,7 +35,7 @@ When using gcc to build the project (which is by default), this enables instrume
 ```console
 lcov -d . --zerocounters
 lcov -d . --capture --initial -o coverage.base
-make -C build/ test
+RNG_SEED=0 make -C build/ test
 lcov -d . --rc lcov_branch_coverage=1 --capture -o coverage.capture
 lcov -d . --add-tracefile coverage.base --add-tracefile coverage.capture -o coverage.total
 genhtml coverage.total -o coverage

--- a/src/emu_cx.c
+++ b/src/emu_cx.c
@@ -1,10 +1,11 @@
 #include <err.h>
-#include <time.h>
 #include <errno.h>
+#include <openssl/rand.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
-#include <stdbool.h>
 
 #include "emulate.h"
 
@@ -47,4 +48,20 @@ unsigned long sys_cx_rng_u8(void)
   sys_cx_rng(&n, sizeof(n));
 
   return n;
+}
+
+/* Link sys_cx_rng to OpenSSL random number generator */
+static int deterministic_random_bytes(unsigned char *buf, int num)
+{
+  sys_cx_rng(buf, num);
+  return 1;
+}
+
+static const RAND_METHOD deterministic_random_methods = {
+    .bytes = deterministic_random_bytes,
+};
+
+void make_openssl_random_deterministic(void)
+{
+  RAND_set_rand_method(&deterministic_random_methods);
 }

--- a/src/emulate.h
+++ b/src/emulate.h
@@ -75,6 +75,7 @@ unsigned long sys_os_ux_1_6(bolos_ux_params_t *params);
 unsigned long sys_cx_hash(cx_hash_t *hash, int mode, const uint8_t *in, size_t len, uint8_t *out, size_t out_len);
 unsigned long sys_cx_rng(uint8_t *buffer, unsigned int length);
 unsigned long sys_cx_rng_u8(void);
+void make_openssl_random_deterministic(void);
 
 unsigned long sys_io_seproxyhal_spi_is_status_sent(void);
 unsigned long sys_io_seproxyhal_spi_send(const uint8_t *buffer, uint16_t length);

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -730,6 +730,7 @@ int main(int argc, char *argv[])
     errx(1, "invalid SDK version");
   }
 
+  make_openssl_random_deterministic();
   reset_memory(true);
 
   if (load_apps(argc - optind, &argv[optind]) != 0)

--- a/tests/syscalls/test_ecdsa.c
+++ b/tests/syscalls/test_ecdsa.c
@@ -1,13 +1,14 @@
 #include <malloc.h>
+#include <setjmp.h>
 #include <stdbool.h>
 #include <string.h>
 
-#include <setjmp.h>
 #include <cmocka.h>
 
-#include "utils.h"
 #include "cx_ec.h"
 #include "cx_hash.h"
+#include "emulate.h"
+#include "utils.h"
 
 #define cx_ecfp_init_private_key sys_cx_ecfp_init_private_key
 #define cx_ecfp_generate_pair sys_cx_ecfp_generate_pair
@@ -79,5 +80,6 @@ int main() {
       cmocka_unit_test(test_ecdsa_secp256k1),
       cmocka_unit_test(test_ecdsa_secp256r1)
   };
+  make_openssl_random_deterministic();
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
* Force the seed when running the code coverage, using `RNG_SEED` environment varible.
* Use `RAND_set_rand_method()` to make `RAND_bytes()` get random bytes from the same PRNG as `sys_cx_rng()`

The aim of this Pull Request is to fix blinking in code coverage analysis such as https://codecov.io/gh/LedgerHQ/speculos/pull/86/changes