### PR TITLE
docker-compose now uses dockerhub image container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   nanos:
     build: .
-    image: speculos
+    image: ledgerhq/speculos
     volumes:
       - ./apps:/speculos/apps
     ports:


### PR DESCRIPTION
**Issue #100**
`docker-compose.yml` wasn't updated when we started using dockerhub image.


**Try it**
`docker-compose up`