### PR TITLE
Fix the cx_aes_iv syscall for SDK 1.6

### DIFF
--- a/src/emulate_1.5.c
+++ b/src/emulate_1.5.c
@@ -4,6 +4,7 @@
 #include "emulate.h"
 
 #include "bolos_syscalls_1.5.h"
+#include "cx_aes.h"
 
 int emulate_1_5(unsigned long syscall, unsigned long *parameters, unsigned long *ret, bool verbose)
 {
@@ -50,6 +51,16 @@ int emulate_1_5(unsigned long syscall, unsigned long *parameters, unsigned long 
            size_t,    length);
 
   SYSCALL1i(os_ux, "(%p)", bolos_ux_params_t *, params, os_ux_1_5);
+
+  SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
+           const cx_aes_key_t *, key,
+           int,                  mode,
+           const uint8_t *,      iv,
+           unsigned int,         iv_len,
+           const uint8_t *,      in,
+           unsigned int,         len,
+           uint8_t *,            out,
+           unsigned int,         out_len);
 
   SYSCALL0(reset);
 

--- a/src/emulate_1.6.c
+++ b/src/emulate_1.6.c
@@ -3,6 +3,7 @@
 
 #include "emulate.h"
 #include "bolos_syscalls_1.6.h"
+#include "cx_aes.h"
 
 int emulate_1_6(unsigned long syscall, unsigned long *parameters, unsigned long *ret, bool verbose)
 {
@@ -71,6 +72,16 @@ int emulate_1_6(unsigned long syscall, unsigned long *parameters, unsigned long 
            unsigned int,         seed_key_length);
 
   SYSCALL1i(os_ux, "(%p)", bolos_ux_params_t *, params, os_ux_1_6);
+
+  SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
+           const cx_aes_key_t *, key,
+           int,                  mode,
+           const uint8_t *,      iv,
+           unsigned int,         iv_len,
+           const uint8_t *,      in,
+           unsigned int,         len,
+           uint8_t *,            out,
+           unsigned int,         out_len);
 
   default:
     retid = emulate_common(syscall, parameters, ret, verbose);

--- a/src/emulate_blue_2.2.5.c
+++ b/src/emulate_blue_2.2.5.c
@@ -3,6 +3,7 @@
 
 #include "emulate.h"
 #include "bolos_syscalls_blue_2.2.5.h"
+#include "cx_aes.h"
 
 int emulate_blue_2_2_5(unsigned long syscall, unsigned long *parameters, unsigned long *ret, bool verbose)
 {
@@ -47,6 +48,17 @@ int emulate_blue_2_2_5(unsigned long syscall, unsigned long *parameters, unsigne
   SYSCALL0i(os_global_pin_is_validated, os_global_pin_is_validated_1_5);
 
   SYSCALL1i(os_ux, "(%p)", bolos_ux_params_t *, params, os_ux_1_6);
+
+  SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
+           const cx_aes_key_t *, key,
+           int,                  mode,
+           const uint8_t *,      iv,
+           unsigned int,         iv_len,
+           const uint8_t *,      in,
+           unsigned int,         len,
+           uint8_t *,            out,
+           unsigned int,         out_len);
+
 
   default:
     retid = emulate_common(syscall, parameters, ret, verbose);


### PR DESCRIPTION
The cx_aes_iv syscall number is indeed different in the SDK 1.6 than in
1.5 and Blue.