### PR TITLE
fixed wrong interpretation of 16bit signed coordinates

### DIFF
--- a/mcu/bagl.py
+++ b/mcu/bagl.py
@@ -576,8 +576,8 @@ class Bagl:
 
     def display_raw_status(self, data):
         if data[0] == SEPROXYHAL_TAG_SCREEN_DISPLAY_RAW_STATUS_START:
-            x = int.from_bytes(data[1:3], byteorder='big')
-            y = int.from_bytes(data[3:5], byteorder='big')
+            x = int.from_bytes(data[1:3], byteorder='big', signed=True)
+            y = int.from_bytes(data[3:5], byteorder='big', signed=True)
             w = int.from_bytes(data[5:7], byteorder='big')
             h = int.from_bytes(data[7:9], byteorder='big')
             bpp = int.from_bytes(data[9:10], byteorder='big')


### PR DESCRIPTION
In layouts like `nnbnn` normally the first and the last lines are displayed half. The other half is outside of the visible screen.

On the simulator, the first line wasn't drawn at all. The reason for this is that the y-coordinate of the bagl image is actually 16bit signed (may be negative) but is interpretated as 32bit unsigned on the simulator.

A coordinate of y=-5 becomes y=65531 which is outside the screen, so it's not drawn at all.

This fix casts the 32bit unsigned in the right value and the missing line is displayed again.