### PR TITLE
Fix install params mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 __pycache__/
 apps/*vault*
 build/
+core

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -68,12 +68,12 @@ static struct app_s *current_app;
 
 static void *get_lower_page_aligned_addr(uintptr_t vaddr)
 {
-  return (void *)((uintptr_t)vaddr & ~((uintptr_t)getpagesize() - 1u));
+  return (void *)((uintptr_t)vaddr & ~((uintptr_t)sysconf(_SC_PAGESIZE) - 1u));
 }
 
 static size_t get_upper_page_aligned_size(size_t vsize)
 {
-  size_t page_size = getpagesize();
+  size_t page_size = sysconf(_SC_PAGESIZE);
   return ((vsize + page_size - 1u) & ~(page_size - 1u));
 }
 

--- a/src/svc.c
+++ b/src/svc.c
@@ -164,7 +164,7 @@ static int setup_alternate_stack(void)
   char *mem;
 
   /* HANDLER_STACK_SIZE + 2 guard pages before/after */
-  page_size = getpagesize();
+  page_size = sysconf(_SC_PAGESIZE);
   size = HANDLER_STACK_SIZE + 2 * page_size;
   mem = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
   if (mem == MAP_FAILED) {


### PR DESCRIPTION
This PR aimed at:
- ignoring core files in versioning in case of a crash
- replacing `getpagesize` by `sysconf(_SC_PAGESIZE)` which is preferred as part of posix
- mapping an extra page for the app's install parameters :
The install parameters of an app are mapped at the end of the `nvram` data of an app.
If this address happens to be the end of a page, speculos crashes when trying to access these parameters
ex: 
- `page_size = 0x1000`, elf size is `0x23d00` which means it will be mapped between `[0x40000000 - 0x40024000]` => as `_install_parameters` are mapped at the end of `_nvram_data` so `0x400023d00` they can be accessed ✔️ 
- `page_size = 0x1000`, elf size is `0x24000` which means it will be mapped between `[0x40000000 - 0x40024000]` => as `_install_parameters` are mapped at the end of `_nvram_data` so `0x400024000` they cannot be accessed ⛔ 
Mapping an additional page helps with this last case 
