### PR TITLE
[tests] improve 'app' fixture

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -3,7 +3,7 @@
 #
 # Support Debian buster & Ubuntu Bionic
 
-FROM python:3.8-slim
+FROM python:3.9-slim
 ENV LANG C.UTF-8
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -22,7 +22,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
   rm -rf /var/lib/apt/lists/
 
 # There are issues with PYTHONHOME if using distro packages, use pip instead.
-RUN pip3 install construct jsonschema mnemonic pycrypto pyelftools pbkdf2 pytest
+RUN pip3 install construct jsonschema mnemonic pycrypto pyelftools pbkdf2 pytest Pillow
 
 # Create SHA256SUMS, download dependencies and verify their integrity
 RUN \

--- a/tests/apps/apdu_client.py
+++ b/tests/apps/apdu_client.py
@@ -5,18 +5,25 @@ import sys
 import time
 import os
 
+from collections import namedtuple
+
+
+AppInfo = namedtuple('AppInfo', ['filepath', 'device', 'name', 'version', 'hash'])
+
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
 
 class APDUClient:
     # default APDU TCP server
     HOST, PORT = ('127.0.0.1', 9999)
 
-    def __init__(self, path):
-        self.path = path
+    def __init__(self, app_info: AppInfo):
+        self.path = app_info.filepath
         self.process = None
-        # name example: nanos#btc#1.5#5b6693b8.elf
-        root, ext = os.path.splitext(path)
-        self.model, self.name, self.sdk, self.revision = os.path.basename(root).split('#')
+        self.name = app_info.name
+        self.model = app_info.device
+        self.sdk = app_info.version
+        self.revision = app_info.hash
         self.touch_events = []
 
     def run(self, headless=True, finger_port=0, deterministic_rng='', seed="", rampage="", args=[]):

--- a/tests/apps/apdu_client.py
+++ b/tests/apps/apdu_client.py
@@ -8,14 +8,14 @@ import os
 from collections import namedtuple
 
 
-AppInfo = namedtuple('AppInfo', ['filepath', 'device', 'name', 'version', 'hash'])
+AppInfo = namedtuple("AppInfo", ["filepath", "device", "name", "version", "hash"])
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 class APDUClient:
     # default APDU TCP server
-    HOST, PORT = ('127.0.0.1', 9999)
+    HOST, PORT = ("127.0.0.1", 9999)
 
     def __init__(self, app_info: AppInfo):
         self.path = app_info.filepath
@@ -26,30 +26,38 @@ class APDUClient:
         self.revision = app_info.hash
         self.touch_events = []
 
-    def run(self, headless=True, finger_port=0, deterministic_rng='', seed="", rampage="", args=[]):
-        '''Launch an app.'''
+    def run(
+        self,
+        headless=True,
+        finger_port=0,
+        deterministic_rng="",
+        seed="",
+        rampage="",
+        args=[],
+    ):
+        """Launch an app."""
 
         # if the app is already running, do nothing
         if self.process:
             return
 
-        cmd = [ os.path.join(SCRIPT_DIR, '..', '..', 'speculos.py') ]
+        cmd = [os.path.join(SCRIPT_DIR, "..", "..", "speculos.py")]
         cmd += args
         if headless:
-            cmd += [ '--display', 'headless' ]
+            cmd += ["--display", "headless"]
         if finger_port:
-            cmd += ['--finger-port', str(finger_port)]
+            cmd += ["--finger-port", str(finger_port)]
         if deterministic_rng:
-            cmd += ['--deterministic-rng', deterministic_rng]
+            cmd += ["--deterministic-rng", deterministic_rng]
         if seed:
-            cmd += ['--seed', seed]
+            cmd += ["--seed", seed]
         if rampage:
-            cmd += ['--rampage', rampage]
-        cmd += [ '--model', self.model ]
-        cmd += [ '--sdk', self.sdk ]
-        cmd += [ self.path ]
+            cmd += ["--rampage", rampage]
+        cmd += ["--model", self.model]
+        cmd += ["--sdk", self.sdk]
+        cmd += [self.path]
 
-        print('[*]', cmd)
+        print("[*]", cmd)
         self.process = subprocess.Popen(cmd)
         time.sleep(1)
 
@@ -66,12 +74,12 @@ class APDUClient:
         self.process.wait()
 
     def _recvall(self, s, size):
-        data = b''
+        data = b""
         while size > 0:
             try:
                 tmp = s.recv(size)
             except ConnectionResetError:
-                tmp = b''
+                tmp = b""
             if len(tmp) == 0:
                 print("[-] connection with client closed", file=sys.stderr)
                 return None
@@ -84,26 +92,26 @@ class APDUClient:
         if data is None:
             return None
 
-        size = int.from_bytes(data, byteorder='big')
+        size = int.from_bytes(data, byteorder="big")
         packet = self._recvall(s, size)
-        status = int.from_bytes(self._recvall(s, 2), 'big')
+        status = int.from_bytes(self._recvall(s, 2), "big")
         return packet, status
 
     def _exchange(self, s, packet, verbose):
-        packet = len(packet).to_bytes(4, 'big') + packet
+        packet = len(packet).to_bytes(4, "big") + packet
         if verbose:
-            print('[>]', binascii.hexlify(packet))
+            print("[>]", binascii.hexlify(packet))
         s.sendall(packet)
 
         data, status = self._recv_packet(s)
 
         if verbose:
-            print('[<]', binascii.hexlify(data), hex(status))
+            print("[<]", binascii.hexlify(data), hex(status))
 
         return data, status
 
     def exchange(self, packet, verbose=False):
-        '''Exchange a packet with the app APDU TCP server.'''
+        """Exchange a packet with the app APDU TCP server."""
 
         for i in range(0, 5):
             try:

--- a/tests/apps/conftest.py
+++ b/tests/apps/conftest.py
@@ -52,13 +52,13 @@ def list_apps_to_test(app_dir) -> List[AppInfo]:
                 device=matching.group(1),
                 name=matching.group(2),
                 version=matching.group(3),
-                hash=matching.group(4)
+                hash=matching.group(4),
             )
         )
     return all_apps
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def app(request):
     _app = APDUClient(request.param)
     yield _app
@@ -69,7 +69,9 @@ def pytest_generate_tests(metafunc):
     # retrieve the list of apps in the ../apps directory
     app_dir = os.path.join(SCRIPT_DIR, os.pardir, os.pardir, "apps")
     apps = list_apps_to_test(app_dir)
-    if not hasattr(metafunc.cls, 'app_names') or not isinstance(metafunc.cls.app_names, list):
+    if not hasattr(metafunc.cls, "app_names") or not isinstance(
+        metafunc.cls.app_names, list
+    ):
         pytest.fail(
             "The TestClass {metafunc.cls} does not have a correct 'app_names' attribute. \n"
             "The 'app_names' attribute must contain a list of app names that will be"

--- a/tests/apps/test_ram_page.py
+++ b/tests/apps/test_ram_page.py
@@ -1,12 +1,9 @@
-import struct
-import time
-
-
 class TestRamPage:
     '''Tests for Vault app.'''
 
-    def test_access_ram_page(self, app, stop_app):
-        app.run(headless=True)
+    app_names = ["ram-page"]
 
+    def test_access_ram_page(self, app):
+        app.run(headless=True)
         response, status = app.exchange(bytes.fromhex("e0010000"))
         assert status == 0x9000

--- a/tests/apps/utils.py
+++ b/tests/apps/utils.py
@@ -1,0 +1,32 @@
+import socket
+import time
+
+
+class Vnc:
+    def __init__(self, port):
+        self.s = self.connect(port)
+
+    def connect(self, port):
+        for i in range(0, 5):
+            try:
+                s = socket.create_connection(("127.0.0.1", port), timeout=0.5)
+                connected = True
+                break
+            except ConnectionRefusedError:
+                time.sleep(0.2)
+                connected = False
+
+        assert connected
+        return s
+
+    def auth(self, password=None):
+        # recv server protocol version
+        data = self.s.recv(4096)
+        # send client protocol version
+        self.s.sendall(data)
+        # receive security types supported
+        data = self.s.recv(2)
+        if not password:
+            assert data == b"\x01\x01"
+        else:
+            assert data == b"\x01\x02"


### PR DESCRIPTION
The app fixture was requiring an extrafeature to be stopped.
In case of failure, the APDUClient was not properly killed,
thus leading to cascading test cases. This commit aims to
fix that.