### PR TITLE
syscalls: add cx_sha224_init

### DIFF
--- a/src/bolos/cx_hash.h
+++ b/src/bolos/cx_hash.h
@@ -247,6 +247,7 @@ int sys_cx_hash_sha256(const unsigned char *in, unsigned int len,
 
 #define sys_cx_blake2b_init   cx_blake2b_init
 #define sys_cx_blake2b_init2  cx_blake2b_init2
+#define sys_cx_sha224_init    cx_sha224_init
 #define sys_cx_sha256_init    cx_sha256_init
 #define sys_cx_sha512_init    cx_sha512_init
 #define sys_cx_ripemd160_init cx_ripemd160_init

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -296,6 +296,8 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL0(cx_rng_u8);
 
+  SYSCALL1(cx_sha224_init, "(%p)", cx_sha256_t *, hash);
+
   SYSCALL1(cx_sha256_init, "(%p)", cx_sha256_t *, hash);
 
   SYSCALL1(cx_sha512_init, "(%p)", cx_sha512_t *, hash);


### PR DESCRIPTION
Fix #139.

Unfortunately, there is no easy way to add test for this (but running an app).