### PR TITLE
LVFM-846: add missing syscall to Speculos' Blue emulation

### DIFF
--- a/src/bolos/cx.h
+++ b/src/bolos/cx.h
@@ -20,25 +20,3 @@ typedef union {
   cx_sha512_t sha512;
   cx_ripemd160_t ripemd160;
 } cx_hash_for_hmac_ctx;
-
-/**
- * HMAC context.
- */
-typedef struct {
-  cx_hash_for_hmac_ctx hash_ctx;
-  uint8_t key[128];
-} cx_hmac_ctx;
-
-/* Aliases for compatibility with the old SDK */
-typedef cx_hmac_ctx cx_hmac_t;
-typedef cx_hmac_ctx cx_hmac_ripemd160_t;
-typedef cx_hmac_ctx cx_hmac_sha256_t;
-typedef cx_hmac_ctx cx_hmac_sha512_t;
-
-void cx_scc_struct_check_hashmac(const cx_hmac_t *hmac);
-int cx_hmac_sha256(const unsigned char *key, unsigned int key_len,
-                   const unsigned char *in, unsigned int len,
-                   unsigned char *out, unsigned int out_len);
-int cx_hmac_sha512(const unsigned char *key, unsigned int key_len,
-                   const unsigned char *in, unsigned int len,
-                   unsigned char *out, unsigned int out_len);

--- a/src/bolos/cx_hash.h
+++ b/src/bolos/cx_hash.h
@@ -243,8 +243,6 @@ int cx_hash_final(cx_hash_ctx *ctx, uint8_t *digest);
 int sys_cx_hash_sha256(const unsigned char *in, unsigned int len,
                        unsigned char *out, unsigned int out_len);
 
-#define sys_cx_hmac_sha256 cx_hmac_sha256
-
 #define sys_cx_blake2b_init   cx_blake2b_init
 #define sys_cx_blake2b_init2  cx_blake2b_init2
 #define sys_cx_sha224_init    cx_sha224_init

--- a/src/bolos/cx_hmac.c
+++ b/src/bolos/cx_hmac.c
@@ -3,7 +3,7 @@
 #include <sys/types.h>
 
 #include "cx.h"
-#include "cx_hash.h"
+#include "cx_hmac.h"
 //#include "cx_utils.h"
 #include "bolos/exception.h"
 

--- a/src/bolos/cx_hmac.h
+++ b/src/bolos/cx_hmac.h
@@ -1,10 +1,32 @@
 #pragma once
 
+/**
+ * HMAC context.
+ */
+typedef struct {
+  cx_hash_for_hmac_ctx hash_ctx;
+  uint8_t key[128];
+} cx_hmac_ctx;
+
+/* Aliases for compatibility with the old SDK */
+typedef cx_hmac_ctx cx_hmac_t;
+typedef cx_hmac_ctx cx_hmac_ripemd160_t;
+typedef cx_hmac_ctx cx_hmac_sha256_t;
+typedef cx_hmac_ctx cx_hmac_sha512_t;
+
+void cx_scc_struct_check_hashmac(const cx_hmac_t *hmac);
+int cx_hmac_sha256(const unsigned char *key, unsigned int key_len,
+                   const unsigned char *in, unsigned int len,
+                   unsigned char *out, unsigned int out_len);
+
 int cx_hmac_init(cx_hmac_ctx *ctx, cx_md_t hash_id, const uint8_t *key,
                  size_t key_len);
 int cx_hmac_update(cx_hmac_ctx *ctx, const uint8_t *data, size_t data_len);
 int cx_hmac_final(cx_hmac_ctx *ctx, uint8_t *out, size_t *out_len);
 
+int cx_hmac_sha512(const unsigned char *key, unsigned int key_len,
+                   const unsigned char *in, unsigned int len,
+                   unsigned char *out, unsigned int out_len);
 int cx_hmac_sha512_init(cx_hmac_sha512_t *hmac, const unsigned char *key,
                         unsigned int key_len);
 
@@ -12,3 +34,6 @@ int sys_cx_hmac(cx_hmac_t *hmac, int mode, const unsigned char *in,
                 unsigned int len, unsigned char *out, unsigned int out_len);
 int sys_cx_hmac_sha256_init(cx_hmac_sha256_t *hmac, const unsigned char *key,
                             unsigned int key_len);
+
+#define sys_cx_hmac_sha256 cx_hmac_sha256
+#define sys_cx_hmac_sha512 cx_hmac_sha512

--- a/src/bolos/cx_scc.c
+++ b/src/bolos/cx_scc.c
@@ -2,6 +2,7 @@
 
 #include "bolos/exception.h"
 #include "cx.h"
+#include "cx_hmac.h"
 
 /* ======================================================================== */
 /* ===  MISC  === MISC === MISC === MISC ===  MISC  === MISC ===  MISC  === */

--- a/src/bolos/os_bip32.c
+++ b/src/bolos/os_bip32.c
@@ -8,6 +8,7 @@
 #include "bolos/exception.h"
 #include "cx.h"
 #include "cx_ec.h"
+#include "cx_hmac.h"
 #include "cx_math.h"
 #include "cx_utils.h"
 #include "emulate.h"

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -376,6 +376,24 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
   SYSCALL2(os_endorsement_get_public_key_certificate, "(%d, %p)",
            unsigned char,   index,
            unsigned char *, buffer);
+
+  SYSCALL6(cx_hmac_sha512, "(%p, %u, %p, %u, %p, %u)",
+           const unsigned char *, key,
+           unsigned int,          key_len,
+           const unsigned char *, in,
+           unsigned int,          len,
+           unsigned char *,       out,
+           unsigned int,          out_len);
+
+  SYSCALL8(os_perso_derive_node_bip32_seed_key, "(0x%x, 0x%x, %p, %u, %p, %p, %p, %u)",
+           unsigned int,         mode,
+           cx_curve_t,           curve,
+           const unsigned int *, path,
+           unsigned int,         pathLength,
+           unsigned char *,      privateKey,
+           unsigned char *,      chain,
+           unsigned char *,      seed_key,
+           unsigned int,         seed_key_length);
   /* clang-format off */
 
   default:

--- a/src/emulate.h
+++ b/src/emulate.h
@@ -74,6 +74,10 @@ unsigned long sys_os_perso_derive_node_with_seed_key(
     unsigned int mode, cx_curve_t curve, const unsigned int *path,
     unsigned int pathLength, unsigned char *privateKey, unsigned char *chain,
     unsigned char *seed_key, unsigned int seed_key_length);
+unsigned long sys_os_perso_derive_node_bip32_seed_key(
+    unsigned int mode, cx_curve_t curve, const unsigned int *path,
+    unsigned int pathLength, unsigned char *privateKey, unsigned char *chain,
+    unsigned char *seed_key, unsigned int seed_key_length);
 unsigned long sys_os_perso_isonboarded(void);
 unsigned long sys_os_setting_get(unsigned int setting_id, uint8_t *value,
                                  size_t maxlen);

--- a/src/emulate_blue_2.2.5.c
+++ b/src/emulate_blue_2.2.5.c
@@ -1,6 +1,7 @@
 #include <err.h>
 #include <stdio.h>
 
+#include "bolos/cx.h"
 #include "bolos/cx_aes.h"
 #include "bolos_syscalls_blue_2.2.5.h"
 #include "emulate.h"

--- a/tests/syscalls/test_bip32.c
+++ b/tests/syscalls/test_bip32.c
@@ -14,9 +14,6 @@
 
 #define MAX_CHAIN_LEN 5
 
-#define sys_os_perso_derive_node_bip32_seed_key                                \
-  sys_os_perso_derive_node_with_seed_key
-
 typedef struct {
   uint32_t index;
   const char *chain_code;


### PR DESCRIPTION
A Blue device with firmware 2.2.10-ee(l)(d) allow to call the `os_perso_derive_node_bip32_seed_key()` and `cx_hmac_sha512()` Bolos syscalls. However it is not possible for a Blue app running in Speculos, although the code for these syscalls is emulated for LNS/LNX. The syscall interface to these emulated functions is missing in Speculos' Blue emulation. 

This PR adds the appropriate syscall interfaces to these 2 Bolos emulated functions.
All tests green.