### PR TITLE
recognize SEPROXYHAL_TAG_PRINTF and log from Nano X

### DIFF
--- a/mcu/seproxyhal.py
+++ b/mcu/seproxyhal.py
@@ -22,6 +22,8 @@ class SephTag(IntEnum):
     USB_EP_PREPARE              = 0x50
 
     RAPDU                       = 0x53
+    PRINTC_STATUS               = 0x5f
+
     GENERAL_STATUS              = 0x60
     GENERAL_STATUS_LAST_COMMAND = 0x0000
     SCREEN_DISPLAY_STATUS       = 0x65
@@ -254,7 +256,7 @@ class SeProxyHal:
 
         self.logger.debug(f"received (tag: {tag:#04x}, size: {size:#04x}): {data!r}")
 
-        if tag & 0xf0 == SephTag.GENERAL_STATUS:
+        if tag & 0xf0 == SephTag.GENERAL_STATUS or tag == SephTag.PRINTC_STATUS:
             ret = None
             if tag == SephTag.GENERAL_STATUS:
                 if int.from_bytes(data[:2], 'big') == SephTag.GENERAL_STATUS_LAST_COMMAND:
@@ -281,7 +283,7 @@ class SeProxyHal:
                 if screen.rendering == RENDER_METHOD.PROGRESSIVE:
                     screen.screen_update()
 
-            elif tag == SephTag.PRINTF_STATUS:
+            elif tag == SephTag.PRINTF_STATUS or tag == SephTag.PRINTC_STATUS:
                 for b in [ chr(b) for b in data ]:
                     if b == '\n':
                         self.logger.info(f"printf: {self.printf_queue}")


### PR DESCRIPTION
Before this patch, running a Nano X app in debug mode with `DEFINES += HAVE_PRINTF PRINTF=mcu_usb_printf` would fail almost immediately with this error:

```
01:48:04.533:seproxyhal: unknown tag: 0x5f
```

That "unknown tag" comes from this line in the nano x SDK:

https://github.com/LedgerHQ/nanox-secure-sdk/blob/master/src/os_io_seproxyhal.c#L1405

```
void mcu_usb_printc(unsigned char c) {
  unsigned char buf[4];
#ifdef TARGET_NANOX
  buf[0] = SEPROXYHAL_TAG_PRINTF;
```

its value is defined here:

https://github.com/LedgerHQ/nanox-secure-sdk/blob/master/include/seproxyhal_protocol.h#L173

`#define SEPROXYHAL_TAG_PRINTF 0x5F // <bytes to push to the printf buffer>`

...so in speculos I defined that tag (even though it's not a "general status") and enabled logging of the `PRINTF`s from my nano x build.

