### PR TITLE
Added `--xy` option to customize window positioning from command-line.

### DIFF
--- a/mcu/display.py
+++ b/mcu/display.py
@@ -10,7 +10,7 @@ from .vnc import VNC
 
 Server = Union[ApduServer, FakeButton, FakeFinger, SeProxyHal, VNC]
 
-DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size")
+DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size x y")
 ServerArgs = namedtuple("ServerArgs", "apdu button finger seph vnc")
 
 Model = namedtuple('Model', 'name screen_size box_position box_size')

--- a/mcu/screen.py
+++ b/mcu/screen.py
@@ -71,8 +71,14 @@ class App(QMainWindow):
         # Take in account multiple screens and their geometry:
         current_screen_x = qt_app.primaryScreen().geometry().x()
         current_screen_y = qt_app.primaryScreen().geometry().y()
-        window_x = settings.value("window_x", current_screen_x + DEFAULT_WINDOW_X, int)
-        window_y = settings.value("window_y", current_screen_y + DEFAULT_WINDOW_Y, int)
+        if display.x is None:
+            window_x = settings.value("window_x", current_screen_x + DEFAULT_WINDOW_X, int)
+        else:
+            window_x = display.x
+        if display.y is None:
+            window_y = settings.value("window_y", current_screen_y + DEFAULT_WINDOW_Y, int)
+        else:
+            window_y = display.y
         window_width = (self.width + box_size_x) * display.pixel_size
         window_height = (self.height + box_size_y) * display.pixel_size
 

--- a/speculos.py
+++ b/speculos.py
@@ -175,6 +175,7 @@ if __name__ == '__main__':
     group = parser.add_argument_group('display arguments', 'These arguments might only apply to one of the display method.')
     group.add_argument('--display', default='qt', choices=['headless', 'qt', 'text'])
     group.add_argument('--ontop', action='store_true', help='The window stays on top of all other windows')
+    group.add_argument('--xy', action='store', help='Window position in "XxY" format (eg. "--xy 30x100").')
     group.add_argument('--keymap', action='store', help="Text UI keymap in the form of a string (e.g. 'was' => 'w' for left button, 'a' right, 's' both). Default: arrow keys")
     group.add_argument('--progressive', action='store_true', help='Enable step-by-step rendering of graphical elements')
     group.add_argument('--zoom', help='Display pixel size.', type=int, choices=range(1, 11))
@@ -202,6 +203,10 @@ if __name__ == '__main__':
 
     if args.ontop and args.display != 'qt':
         logger.error("-o (--ontop) can only be used with --display qt")
+        sys.exit(1)
+
+    if args.xy and args.display != 'qt':
+        logger.error("--xy can only be used with --display qt")
         sys.exit(1)
 
     if args.zoom and args.display != 'qt':
@@ -277,7 +282,11 @@ if __name__ == '__main__':
         }
         zoom = default_zoom.get(args.model)
 
-    display_args = display.DisplayArgs(args.color, args.model, args.ontop, rendering, args.keymap, zoom)
+    x, y = None, None
+    if args.xy:
+        x, y = (int(i) for i in args.xy.split('x'))
+
+    display_args = display.DisplayArgs(args.color, args.model, args.ontop, rendering, args.keymap, zoom, x, y)
     server_args = display.ServerArgs(apdu, button, finger, seph, vnc)
     screen = Screen(display_args, server_args)
     screen.run()


### PR DESCRIPTION
Use case is to start multiple `speculos` instances:
- Instances are not started in sequence but in parallel.
- In that case we cannot rely on QT settings for that customization.