### PR TITLE
ci: add a warning when executing speculos.py from the Docker Hub image

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -57,6 +57,10 @@ jobs:
         tag_with_sha: true
         tags: latest
 
+    - name: Apply DockerHub deprecation patch
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: patch < tools/deprecate-dockerhub.patch
+
     - name: Publish to DockerHub
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v1
@@ -68,6 +72,10 @@ jobs:
         password: ${{ secrets.dockerhub_password }}
         tag_with_sha: true
         tags: latest
+
+    - name: Reverse the DockerHub deprecation patch
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: patch --reverse < tools/deprecate-dockerhub.patch
 
     - name: Rebuild with code coverage instrumentation
       env:

--- a/tools/deprecate-dockerhub.patch
+++ b/tools/deprecate-dockerhub.patch
@@ -1,0 +1,14 @@
+diff --git a/speculos.py b/speculos.py
+index 11bdd0e..7eebd42 100755
+--- a/speculos.py
++++ b/speculos.py
+@@ -184,6 +184,9 @@ if __name__ == '__main__':
+     args.model.lower()
+ 
+     logger = setup_logging(args)
++    logger.error("The DockerHub image is deprecated, please use the GitHub Packages image")
++    logger.error("New docker image URL: docker://ghcr.io/ledgerhq/speculos")
++    logger.error("From the command line: docker pull ghcr.io/ledgerhq/speculos")
+ 
+     rendering = seproxyhal.RENDER_METHOD.FLUSHED
+     if args.progressive:


### PR DESCRIPTION
I hope this warning will be read by speculos users, in order to make them update
the docker image URL in their scripts.