### PR TITLE
ci: prevent failure if the push to DockerHub fails

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -46,17 +46,6 @@ jobs:
         make -C build/ test
         pytest
 
-    - name: Publish to DockerHub
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v1
-      with:
-        repository: ledgerhq/speculos
-        dockerfile: Dockerfile
-        username: ${{ secrets.dockerhub_username }}
-        password: ${{ secrets.dockerhub_password }}
-        tag_with_sha: true
-        tags: latest
-
     - name: Build and publish to GitHub Packages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v1
@@ -65,6 +54,18 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+        tag_with_sha: true
+        tags: latest
+
+    - name: Publish to DockerHub
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v1
+      continue-on-error: true
+      with:
+        repository: ledgerhq/speculos
+        dockerfile: Dockerfile
+        username: ${{ secrets.dockerhub_username }}
+        password: ${{ secrets.dockerhub_password }}
         tag_with_sha: true
         tags: latest
 
@@ -82,4 +83,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         name: codecov-speculos
-        fail_ci_if_error: true


### PR DESCRIPTION
DockerHub is deprecated and credentials to the speculos image has been
(hopefully temporarily) revoked, making the next steps of the job fail.