### PR TITLE
Add support for automation to the Nano X

### DIFF
--- a/mcu/bagl.py
+++ b/mcu/bagl.py
@@ -69,8 +69,8 @@ class Bagl:
         self.draw_state = DrawState(0, 0, 0, 0, [], 0, 0, 0)
         self.logger = logging.getLogger("bagl")
 
-    def refresh(self):
-        self.m.update()
+    def refresh(self) -> bool:
+        return self.m.update()
 
     def hal_draw_bitmap_within_rect(self, x, y, width, height, colors, bpp, bitmap, restore=None):
         if bpp == 3 or bpp > 4:

--- a/mcu/bagl.py
+++ b/mcu/bagl.py
@@ -504,7 +504,7 @@ class Bagl:
                          text,
                          context_encoding)
 
-        return (text, component.x + halignment, y)
+        return (text, (component.x + halignment, y))
 
     def _display_get_alignment(self, component, context, context_encoding):
         halignment = 0

--- a/mcu/display.py
+++ b/mcu/display.py
@@ -67,7 +67,7 @@ class Display(ABC):
         pass
 
     @abstractmethod
-    def screen_update(self):
+    def screen_update(self) -> bool:
         pass
 
     def add_notifier(self, klass):

--- a/mcu/headless.py
+++ b/mcu/headless.py
@@ -25,8 +25,8 @@ class Headless(Display):
         if MODELS[self.model].name == 'blue':
             self.screen_update()    # Actually, this method doesn't work
 
-    def screen_update(self):
-        self.bagl.refresh()
+    def screen_update(self) -> bool:
+        return self.bagl.refresh()
 
     def run(self):
         while True:
@@ -52,6 +52,8 @@ class HeadlessPaintWidget(FrameBuffer):
         if self.pixels:
             self._redraw()
             self.pixels = {}
+            return True
+        return False
 
     def _redraw(self):
         if self.vnc:

--- a/mcu/nanox_ocr.py
+++ b/mcu/nanox_ocr.py
@@ -1,0 +1,169 @@
+from typing import Any, List, Union, Mapping, Optional
+from dataclasses import dataclass
+import functools
+import string
+
+from . import bagl_font
+
+BitMap = bytes
+BitVector = str  # a string of '1' and '0'
+Width = int  # width
+CharWidth = Width
+Char = str  # a single character string (chars are 1-char strings in Python)
+
+
+__FONT_MAP = {}
+
+DISPLAY_CHARS = string.ascii_letters + string.digits + string.punctuation
+
+
+def cache_font(f):
+    __font_char_cache = {}
+
+    @functools.wraps(f)
+    def wrapper(byte_string: bytes):
+        if byte_string not in __font_char_cache:
+            __font_char_cache[byte_string] = f(byte_string)
+        return __font_char_cache[byte_string]
+    return wrapper
+
+
+
+@dataclass
+class BitMapChar:
+    char: bagl_font.FontCharacter
+    bitmap: bytes
+
+
+def split(bits: BitVector, n: Width) -> List[BitVector]:
+    """
+    Split a bit array (string of '1' and '0')
+    into an arbitrary list of n-sized bit arrays.
+
+    Useful if you want to display a character from a bitmap
+    """
+    output = []
+    bit_list = bits[:]
+    while bit_list:
+        bit_list_to_append = bit_list[:n]
+        # do padding
+        # bit_list_to_append += '0' * (n - len(bit_list_to_append))
+        output.append(bit_list_to_append)
+        bit_list = bit_list[n:]
+    return output
+
+
+def split_bytes(bytes_elems: BitMap, n: CharWidth):
+    """Useful to display a bitmap character"""
+    bits = "".join("{0:08b}".format(x)[::-1] for x in bytes_elems)
+    return split(bits, n)
+
+
+def get_font_char(char: str, font: bagl_font.Font):
+    ord_char = ord(char)
+    if ord_char > font.last_char or ord_char > font.last_char:
+        raise ValueError(f"char {char} is not displayable with font_id {font.font_id}")
+
+
+def get_font(font_id: int) -> bagl_font.Font:
+    font = bagl_font.get(font_id)
+    if not font:
+        raise ValueError(f"Could not get font with font_id={font_id}")
+    return font
+
+
+def get_char(font: bagl_font.Font, char: str) -> BitMapChar:
+    if len(char) != 1 or char not in DISPLAY_CHARS:
+        raise ValueError(f"could not print {char}")
+    return get_font_map(font)[char]
+
+
+def display_char(font: bagl_font.Font, char: str) -> None:
+    char = get_char(font, char)
+    print("\n".join(split_bytes(char.bitmap, font.bpp * char.char.char_width)))
+
+
+def get_font_map(font: bagl_font.Font):
+    if font.font_id not in __FONT_MAP:
+        __FONT_MAP[font.font_id] = _get_font_map(font)
+    return __FONT_MAP[font.font_id]
+
+
+def _get_font_map(font: bagl_font.Font) -> Mapping[Char, BitMapChar]:
+    font_map = {}
+    for ord_char, font_char in zip(
+        range(font.first_char, font.last_char), font.characters
+    ):
+        font_map[chr(ord_char)] = BitMapChar(
+            font_char,
+            bytes(
+                font.bitmap[
+                    font_char.bitmap_offset:(
+                        font_char.bitmap_offset
+                        + font_char.bitmap_byte_count
+                    )
+                ]
+            ),
+        )
+    return font_map
+
+
+@cache_font
+def find_char_from_bitmap(bitmap: BitMap):
+    """
+     Find a character from a bitmap
+    >>> font = get_font(4)
+    >>> char = get_char(font, 'c')
+    >>> find_char_from_bitmap(char.bitmap)
+    'c'
+    """
+    all_values = []
+    for font in bagl_font.FONTS:
+        font_map = get_font_map(font)
+        for character_value, bitmap_struct in font_map.items():
+            if bitmap_struct.bitmap.startswith(bitmap):
+                # sometimes (but not always) the bitmap being passed is shortened
+                # by one '\x00' byte, not matching the exact bitmap
+                # provided in the font. Hence the 'residual' computation
+                residual_bytes: bytes = bitmap_struct.bitmap[len(bitmap):]
+                if all(b == 0 for b in residual_bytes):
+                    all_values.append(character_value)
+        if all_values:
+            return max([x for x in all_values])
+
+class NanoXOCR:
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.text = b""
+        self.x, self.y = (0, 0)
+        self.last_x, self.last_y = (0, 0)
+
+    def analyze_bitmap(self, data: bytes):
+        if data[0] != 0:
+            return
+
+        x = int.from_bytes(data[1:3], byteorder="big", signed=True)
+        y = int.from_bytes(data[3:5], byteorder="big", signed=True)
+        bpp = int.from_bytes(data[9:10], byteorder="big")
+        color_size = 4 * (1 << bpp)
+        bitmap = data[10+color_size:]
+
+        char = find_char_from_bitmap(bitmap)
+        if char:
+            if self.text is b"":
+                self.x, self.y = (x, y)
+            elif y > self.last_y:
+                self.text += b"\n"
+            if char == "\x80":
+                char = " "
+            self.text += char.encode()
+
+        self.last_x, self.last_y = x, y
+
+    def get_text(self, reset=True):
+        text, x, y = self.text, self.x, self.y
+        if reset:
+            self.reset()
+        return text, x, y

--- a/mcu/nanox_ocr.py
+++ b/mcu/nanox_ocr.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union, Mapping, Optional
+from typing import Any, List, Tuple, Union, Mapping, Optional
 from dataclasses import dataclass
 import functools
 import string
@@ -162,8 +162,8 @@ class NanoXOCR:
 
         self.last_x, self.last_y = x, y
 
-    def get_text(self, reset=True):
+    def get_text(self, reset=True) -> Tuple[bytes, Tuple[int, int]]:
         text, x, y = self.text, self.x, self.y
         if reset:
             self.reset()
-        return text, x, y
+        return text, (x, y)

--- a/mcu/screen.py
+++ b/mcu/screen.py
@@ -42,6 +42,10 @@ class PaintWidget(QWidget):
                 self.mPixmap.height() * self.pixel_size)
         qp.drawPixmap(0, 0, copied_pixmap )
 
+    def update(self) -> bool:
+        super().update()
+        return self.fb.pixels != {}
+
     def _redraw(self, qp):
         for (x, y), color in self.fb.pixels.items():
             qp.setPen(QColor.fromRgb(color))
@@ -125,8 +129,8 @@ class App(QMainWindow):
 
         self.show()
 
-    def screen_update(self):
-        self.screen.screen_update()
+    def screen_update(self) -> bool:
+        return self.screen.screen_update()
 
     def keyPressEvent(self, event):
         self.screen._key_event(event, True)
@@ -230,8 +234,8 @@ class Screen(Display):
         if MODELS[self.model].name == 'blue':
             self.screen_update()    # Actually, this method doesn't work
 
-    def screen_update(self):
-        self.bagl.refresh()
+    def screen_update(self) -> bool:
+        return self.bagl.refresh()
 
 class QtScreen:
     def __init__(self, display: DisplayArgs, server: ServerArgs) -> None:

--- a/mcu/screen_text.py
+++ b/mcu/screen_text.py
@@ -65,7 +65,7 @@ class TextWidget(FrameBuffer):
     def _redraw(self):
         p = self.pixels
         if p == self.previous_screen:
-            return
+            return False
         else:
             self.previous_screen = p.copy()
 
@@ -84,6 +84,8 @@ class TextWidget(FrameBuffer):
         self.stdscr.addstr(0, 0, ' '*(self.width//2 + 2), curses.color_pair(2))
         self.stdscr.addstr(self.height//2, 0, ' '*(self.width//2 + 2), curses.color_pair(2))
         self.stdscr.refresh()
+
+        return True
 
     def draw_point(self, x, y, color):
         self.pixels[(x, y)] = int(color!=0)
@@ -115,8 +117,8 @@ class TextScreen(Display):
     def display_raw_status(self, data):
         self.bagl.display_raw_status(data)
 
-    def screen_update(self):
-        self.m._redraw()
+    def screen_update(self) -> bool:
+        return self.m._redraw()
 
     def get_keypress(self):
         key = self.m.stdscr.getch()

--- a/mcu/seproxyhal.py
+++ b/mcu/seproxyhal.py
@@ -314,7 +314,7 @@ class SeProxyHal:
 
             # apply automation rules after having replied to the app
             if ret != None:
-                text, x, y = ret
+                text, (x, y) = ret
                 self.apply_automation(text, x, y)
 
         elif tag == SephTag.RAPDU:

--- a/mcu/seproxyhal.py
+++ b/mcu/seproxyhal.py
@@ -6,6 +6,7 @@ import threading
 from enum import IntEnum
 
 from . import usb
+from .nanox_ocr import NanoXOCR
 from .readerror import ReadError
 
 class SephTag(IntEnum):
@@ -149,6 +150,8 @@ class SeProxyHal:
         self.ticker_thread.start()
         self.usb = usb.USB(self.packet_thread.queue_packet)
 
+        self.nanox_ocr = NanoXOCR()
+
     def _recvall(self, size):
         data = b''
         while size > 0:
@@ -264,7 +267,9 @@ class SeProxyHal:
             ret = None
             if tag == SephTag.GENERAL_STATUS:
                 if int.from_bytes(data[:2], 'big') == SephTag.GENERAL_STATUS_LAST_COMMAND:
-                    screen.screen_update()
+                    if screen.screen_update():
+                        if screen.model == "nanox":
+                            ret = self.nanox_ocr.get_text()
 
             elif tag == SephTag.SCREEN_DISPLAY_STATUS:
                 self.logger.debug(f"DISPLAY_STATUS {data!r}")
@@ -274,6 +279,8 @@ class SeProxyHal:
             elif tag == SephTag.SCREEN_DISPLAY_RAW_STATUS:
                 self.logger.debug("SephTag.SCREEN_DISPLAY_RAW_STATUS")
                 screen.display_raw_status(data)
+                if screen.model == "nanox":
+                    self.nanox_ocr.analyze_bitmap(data)
                 # https://github.com/LedgerHQ/nanos-secure-sdk/blob/1f2706941b68d897622f75407a868b60eb2be8d7/src/os_io_seproxyhal.c#L787
                 #
                 # io_seproxyhal_spi_recv() accepts any packet from the MCU after

--- a/speculos.py
+++ b/speculos.py
@@ -197,7 +197,7 @@ if __name__ == '__main__':
             logger.error("invalid ram page argument")
             sys.exit(1)
 
-    if args.display == 'text' and args.model != 'nanos':
+    if args.display == 'text' and args.model not in ['nanos', 'nanox']:
         logger.error(f"unsupported model '{args.model}' with argument --display text")
         sys.exit(1)
 
@@ -238,16 +238,10 @@ if __name__ == '__main__':
 
     automation_path = None
     if args.automation:
-        if args.model == "nanox":
-            logger.error("automation isn't supported on the Nano X")
-            sys.exit(1)
         automation_path = automation.Automation(args.automation)
 
     automation_server = None
     if args.automation_port:
-        if args.model == "nanox":
-            logger.error("automation isn't supported on the Nano X")
-            sys.exit(1)
         automation_server = AutomationServer(("0.0.0.0", args.automation_port), AutomationClient)
         automation_thread = threading.Thread(target=automation_server.serve_forever, daemon=True)
         automation_thread.start()

--- a/src/bolos/bagl.c
+++ b/src/bolos/bagl.c
@@ -107,6 +107,9 @@ unsigned long sys_bagl_hal_draw_bitmap_within_rect(
   }
 
   size_t bitmap_length = bitmap_length_bits / 8;
+  if (bitmap_length_bits % 8 != 0) {
+    bitmap_length += 1;
+  }
   size_t offset = 0;
   len = build_chunk(buf + size, &offset, sizeof(buf) - size, bitmap,
                     bitmap_length);

--- a/tests/apps/resources/btc_getpubkey_nanox.json
+++ b/tests/apps/resources/btc_getpubkey_nanox.json
@@ -1,0 +1,21 @@
+{
+    "version": 1,
+    "rules": [
+        {
+            "regexp": "Address.*",
+            "actions": [
+                [ "button", 2, true ],
+                [ "button", 2, false ]
+            ]
+        },
+        {
+            "text": "Approve",
+            "actions": [
+                [ "button", 1, true ],
+                [ "button", 2, true ],
+                [ "button", 1, false ],
+                [ "button", 2, false ]
+            ]
+        }
+    ]
+}

--- a/tests/apps/test_btc.py
+++ b/tests/apps/test_btc.py
@@ -54,8 +54,6 @@ class TestBtc:
 
         if app.revision == "00000000" and app.model == "nanos":
             pytest.skip("unsupported get pubkey ux for this app version")
-        if app.model == 'nanox':
-            pytest.skip("automation isn't supported on the Nano X")
 
         args = [ '--automation', TestBtc.get_automation_path(f'btc_getpubkey_{app.model}.json') ]
         app.run(args=args)


### PR DESCRIPTION
This PR is based on @dkremer-ledger work, PR #118 (thanks a lot to him!).

To put it short, on the Nano X there is no syscall to display text characters to the screen (because the screen is connected to the SE on a real device) and bitmaps are directly rendered. Some kind of OCR was introduced to reverse that process and tell which character is displayed. `--automation` and `--automation-port` are now working on the Nano X.

To test it:

```
$ ./speculos.py --log-level automation:DEBUG --automation-port 1238 --model nanox ./apps/nanox#btc#1.2#57272a0f.elf 
[*] speculos launcher revision: 78aaf57
[*] using SDK version 1.2
[...]
11:00:12.008:automation: broadcast {'text': 'Application\nis ready', 'x': 35, 'y': 20} to []
11:00:13.396:automation: broadcast {'text': 'Settings', 'x': 41, 'y': 35} to []
11:00:13.636:automation: broadcast {'text': 'Version\n1.5.3', 'x': 43, 'y': 20} to []
11:00:16.068:automation: broadcast {'text': 'Quit', 'x': 52, 'y': 35} to []
```

(Additionally, this PR also fixes a bug truncating some characters one Nano X.)