### PR TITLE
Dockerfile: specify the name of the registry used for base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Prerequisite: a working speculos build.
 
-FROM python:3.8-slim
+FROM docker.io/library/python:3.9-slim
 
 ADD . /speculos
 WORKDIR /speculos

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -3,7 +3,7 @@
 #
 # Support Debian buster & Ubuntu Bionic
 
-FROM python:3.9-slim
+FROM docker.io/library/python:3.9-slim
 ENV LANG C.UTF-8
 
 RUN export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
When using podman 3.1.2 to build Speculos containers, the command prompts the user for a container registry:

    $ podman build -f build.Dockerfile -t ghcr.io/ledgerhq/speculos-builder .
    STEP 1: FROM python:3.9-slim
      ▸ docker.io/library/python:3.9-slim
        quay.io/python:3.9-slim

Avoid this prompt by directly specifying the full name of the image, including the container registry.

While at it, sync `Dockerfile` to Python 3.9 like `build.Dockerfile`.