### PR TITLE
Fix misspellings found using codespell

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -1,0 +1,4 @@
+keypair
+ontop
+tolen
+unstall

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -34,6 +34,14 @@ jobs:
         clangFormatVersion: 11
         fail_ci_if_error: true
 
+    - name: Check misspellings
+      uses: codespell-project/actions-codespell@de089481bd65b71b4d02e34ffb3566b6d189333e
+      with:
+        builtin: clear,rare
+        check_filenames: true
+        ignore_words_file: .codespell-ignore
+        skip: api/swagger/swagger-ui.css,api/swagger/swagger-ui-bundle.js,api/swagger/swagger-ui-standalone-preset.js
+
     - name: Build
       run: |
         cmake -Bbuild -H. -DPRECOMPILED_DEPENDENCIES_DIR=/install -DWITH_VNC=1

--- a/docs/user/automation.md
+++ b/docs/user/automation.md
@@ -38,7 +38,7 @@ Each key is optional.
 - `[ "exit" ]`: exit speculos
 
 The actions of a rule are executed if and only if each rule option matches.
-These actions are applied sucessively according to the ordering of the `actions`
+These actions are applied successively according to the ordering of the `actions`
 list.
 
 The actions of the first rule matched are applied. Further matching rules are

--- a/speculos.py
+++ b/speculos.py
@@ -160,7 +160,7 @@ if __name__ == '__main__':
     parser.add_argument('-l', '--library', default=[], action='append', help='Additional library (eg. Bitcoin:app/btc.elf) which can be called through os_lib_call')
     parser.add_argument('--log-level', default=[], action='append', help='Configure the logger levels (eg. usb:DEBUG), can be specified multiple times')
     parser.add_argument('-m', '--model', default='nanos', choices=list(display.MODELS.keys()))
-    parser.add_argument('-r', '--rampage', help='Additional RAM page and size available to the app (eg. 0x123000:0x100). Supercedes the internal probing for such page.')
+    parser.add_argument('-r', '--rampage', help='Additional RAM page and size available to the app (eg. 0x123000:0x100). Supersedes the internal probing for such page.')
     parser.add_argument('-s', '--seed', default=DEFAULT_SEED, help='BIP39 mnemonic or hex seed. Default to mnemonic: to use a hex seed, prefix it with "hex:"')
     parser.add_argument('-t', '--trace', action='store_true', help='Trace syscalls')
 

--- a/src/bolos/cx_blake2b.c
+++ b/src/bolos/cx_blake2b.c
@@ -486,7 +486,7 @@ int blake2b_final( blake2b_state *S, void *out, size_t outlen )
 }
 
 
-/* =============================== UNSUED =============================== */
+/* =============================== UNUSED =============================== */
 //Following code is not used
 #if defined(BLAKE2_UNUSED)
 /* inlen, at least, should be uint64_t. Others can be size_t. */

--- a/src/bolos/cx_ec.h
+++ b/src/bolos/cx_ec.h
@@ -92,7 +92,7 @@ typedef enum cx_curve_e cx_curve_t;
   cx_curve_t curve;                                                            \
   /** Curve size in bits */                                                    \
   unsigned int bit_size;                                                       \
-  /** component lenth in bytes */                                              \
+  /** component length in bytes */                                             \
   unsigned int length;                                                         \
   /** Curve field */                                                           \
   unsigned char *p;                                                            \

--- a/src/bolos/cx_ec_sdk2.h
+++ b/src/bolos/cx_ec_sdk2.h
@@ -131,7 +131,7 @@ typedef enum cx_curve_e cx_curve_t;
   cx_curve_t curve;                                                            \
   /** Curve size in bits */                                                    \
   unsigned int bit_size;                                                       \
-  /** component lenth in bytes */                                              \
+  /** component length in bytes */                                             \
   unsigned int length;                                                         \
   /**  a coef */                                                               \
   const uint8_t *a;                                                            \

--- a/src/bolos/cx_mpi.c
+++ b/src/bolos/cx_mpi.c
@@ -524,7 +524,7 @@ int cx_mpi_cmp(cx_mpi_t *a, cx_mpi_t *b)
     return CX_INVALID_PARAMETER;
   }
   // TODO be sure the next test is required (numbers may have different size
-  // but still be 'comparables', for exemple if MSB of a number are at 0)
+  // but still be 'comparables', for example if MSB of a number are at 0)
   if (a_len == b_len) {
     // Convert a cx_mpi_t into big-endian bytes form:
     if (BN_bn2binpad(a, a_ptr, a_len) != -1 &&

--- a/src/bolos/cx_rng_rfc6979.c
+++ b/src/bolos/cx_rng_rfc6979.c
@@ -70,7 +70,7 @@ static void cx_rfc6979_bits2octets(cx_rnd_rfc6979_ctx_t *rfc_ctx,
 }
 
 /* ----------------------------------------------------------------------- */
-/* Convert a interger bits string to BE int of r_len bits                  */
+/* Convert a integer bits string to BE int of r_len bits                   */
 /*                                                                         */
 /*  Params:                                                                */
 /*    i    : integer to convert                                            */

--- a/src/bolos/cx_sha256.c
+++ b/src/bolos/cx_sha256.c
@@ -6,7 +6,7 @@
 #include "cx_hash.h"
 #include "cx_utils.h"
 
-/** RAM overlayed  to NES RAM under ST */
+/** RAM overlaid to NES RAM under ST */
 union cx_u {
   cx_sha256_t sha256;
 };

--- a/src/bolos/os.c
+++ b/src/bolos/os.c
@@ -131,7 +131,7 @@ unsigned long sys_os_version(uint8_t *buffer, unsigned int len)
     if (len < kLen)
       return len;
     else
-      return kLen; // This mimick the real behaviour that does return the data
+      return kLen; // This mimics the real behaviour that does return the data
                    // without the '\0'
   }
 

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -311,7 +311,7 @@ static int load_cxlib(char *cxlib_path)
   // First, try to open the cx.elf file specified (could be the one by default):
   int fd = open(cxlib_path, O_RDONLY);
   if (fd == -1) {
-    // Try to use environnement variable CXLIB_PATH:
+    // Try to use environment variable CXLIB_PATH:
     char *path = getenv("CXLIB_PATH");
     if (path == NULL) {
       warnx("failed to open \"%s\" and no CXLIB_PATH environment found!",

--- a/src/svc.c
+++ b/src/svc.c
@@ -223,7 +223,7 @@ int setup_signals(void)
 /*
  * Replace the SVC instruction with an undefined instruction.
  *
- * It generates a SIGILL upon execution, which is catched to handle that
+ * It generates a SIGILL upon execution, which is caught to handle that
  * syscall.
  */
 int patch_svc(void *p, size_t size)

--- a/tools/gdbinit
+++ b/tools/gdbinit
@@ -2298,7 +2298,7 @@ end
 # FIXME64
 #### WARNING ! WARNING !!
 #### More more messy stuff starting !!!
-#### I was thinking about how to do this and then it ocurred me that it could be as simple as this ! :)
+#### I was thinking about how to do this and then it occurred me that it could be as simple as this ! :)
 define stepoframework
     if $ARM == 1
         # bl and bx opcodes
@@ -3206,12 +3206,12 @@ end
 # seems nasm shipping with Mac OS X has problems accepting input from stdin or heredoc
 # input is read into a variable and sent to a temporary file which nasm can read
 define assemble
-    # dont enter routine again if user hits enter
+    # don't enter routine again if user hits enter
     dont-repeat
     if ($argc)
         if (*$arg0 = *$arg0)
         # check if we have a valid address by dereferencing it,
-        # if we havnt, this will cause the routine to exit.
+        # if we haven't, this will cause the routine to exit.
         end
         printf "Instructions will be written to %#x.\n", $arg0
     else
@@ -3263,12 +3263,12 @@ Syntax: assemble <ADDR>
 end
 
 define assemble32
-    # dont enter routine again if user hits enter
+    # don't enter routine again if user hits enter
     dont-repeat
     if ($argc)
         if (*$arg0 = *$arg0)
         # check if we have a valid address by dereferencing it,
-        # if we havnt, this will cause the routine to exit.
+        # if we haven't, this will cause the routine to exit.
         end
         printf "Instructions will be written to %#x.\n", $arg0
     else
@@ -3304,12 +3304,12 @@ Syntax: assemble32 <ADDR>
 end
 
 define assemble64
-    # dont enter routine again if user hits enter
+    # don't enter routine again if user hits enter
     dont-repeat
     if ($argc)
         if (*$arg0 = *$arg0)
         # check if we have a valid address by dereferencing it,
-        # if we havnt, this will cause the routine to exit.
+        # if we haven't, this will cause the routine to exit.
         end
         printf "Instructions will be written to %#x.\n", $arg0
     else
@@ -3392,7 +3392,7 @@ define assemble_gas
           objdump -d -j .text $binfilename; \
           rm -f $binfilename; \
           rm -f $filename; \
-          echo -e "temporaly files deleted.\n"
+          echo -e "temporary files deleted.\n"
 end
 document assemble_gas
 Syntax: assemble_gas
@@ -3470,7 +3470,7 @@ define search
 end
 document search
 Syntax: search <START> <END> <PATTERN>
-| Search for the given pattern beetween $start and $end address.
+| Search for the given pattern between $start and $end address.
 end
 
 
@@ -3493,7 +3493,7 @@ define tip_patch
     printf "\n"
     printf "                   PATCHING MEMORY\n"
     printf "Any address can be patched using the 'set' command:\n"
-    printf "\t`set ADDR = VALUE` \te.g. `set *0x8049D6E = 0x90`\n"
+    printf "\t`set ADDR = VALUE`  e.g. `set *0x8049D6E = 0x90`\n"
     printf "\n"
     printf "                 PATCHING BINARY FILES\n"
     printf "Use `set write` in order to patch the target executable\n"
@@ -3858,7 +3858,7 @@ end
 #   Version 7.4.1 (21/06/2011) - fG!
 #    Added patch sent by sbz, more than 1 year ago, which I forgot to add :-/
 #     This will allow to search for a given pattern between start and end address.
-#     On sbz words: "It's usefull to find call, ret or everything like that." :-)
+#     On sbz words: "It's useful to find call, ret or everything like that." :-)
 #    New command is "search"
 #
 #   Version 7.4 (20/06/2011) - fG!
@@ -3902,7 +3902,7 @@ end
 #
 #   Version 7.1.5 (04/01/2009) - fG!
 #     Fixed crash on Leopard ! There was a If Else condition where the else had no code and that made gdb crash on Leopard (CRAZY!!!!)
-#     Better code indention
+#     Better code indentation
 #
 #   Version 7.1.4 (02/01/2009) - fG!
 #     Bug in show objective c messages with Leopard ???
@@ -3929,7 +3929,7 @@ end
 #   Version 7.0
 #     Added cls command.
 #     Improved documentation of many commands.
-#     Removed bp_alloc, was neither portable nor usefull.
+#     Removed bp_alloc, was neither portable nor useful.
 #     Checking of passed argument(s) in these commands:
 #       contextsize-stack, contextsize-data, contextsize-code
 #       bp, bpc, bpe, bpd, bpt, bpm, bhb,...


### PR DESCRIPTION
`codespell` is a tool which looks for common misspellings in source code. It can be used to check Speculos code with:
    
        git ls-files | grep -v '^api/swagger/' | \
            xargs codespell --ignore-words=.codespell-ignore --check-filenames

Fix the misspellings found using it and add an action in GitHub Actions CI to automatically run it in Pull Requests.

Here is an example of failure reported by codespell: https://github.com/niooss-ledger/speculos/runs/2830337818?check_suite_focus=true#step:8:19