### PR TITLE
os_eip2333: remove unnecessary condition

### DIFF
--- a/src/bolos/os_eip2333.c
+++ b/src/bolos/os_eip2333.c
@@ -176,10 +176,6 @@ static int cx_derive_child_sk(const unsigned char *parent_sk,
     return -1;
   }
   for (i = 0; i < path_len; i++) {
-    if (path[i] > 0xffffffff) {
-      warnx("eip2333 key generation: invalid path");
-      return -1;
-    }
     cx_parent_sk_to_lamport_pk((i == 0 ? parent_sk : child_sk), path[i],
                                lamport_pk);
     lamport_pk[KEY_LENGTH] = 0;


### PR DESCRIPTION
As `path[i]` is an `unsigned int`, it cannot be greater than `0xffffffff`. So the check in function `cx_derive_child_sk` was not
needed, and triggered a warning in LGTM: https://lgtm.com/projects/g/LedgerHQ/speculos/snapshot/7839414ae493f551fbe0850bb249b7617cb46c2d/files/src/bolos/os_eip2333.c?sort=name&dir=ASC&mode=heatmap#L179

Remove this check to silence LGTM.