### PR TITLE
Optimize ed25519 implementation a little

### DIFF
--- a/src/bolos/cx_ed25519.c
+++ b/src/bolos/cx_ed25519.c
@@ -15,7 +15,7 @@ static const char *constant_q = "5789604461865809771178549250434395392663499233"
 static const char *constant_I = "1968116137670750595680707930498854201544606651"
                                 "5923890162744021073123829784752";
 static bool initialized;
-static BIGNUM *d1, *d2, *I, *q, *two;
+static BIGNUM *d1, *I, *q, *two;
 static const BIGNUM *one;
 static BN_CTX *ctx;
 
@@ -27,17 +27,15 @@ static int initialize(void)
   a = BN_new();
   two = BN_new();
   d1 = BN_new();
-  d2 = BN_new();
   q = BN_new();
   I = BN_new();
 
-  if (ctx == NULL || a == NULL || two == NULL || d1 == NULL || d2 == NULL ||
-      q == NULL || I == NULL) {
+  if (ctx == NULL || a == NULL || two == NULL || d1 == NULL || q == NULL ||
+      I == NULL) {
     BN_CTX_free(ctx);
     BN_free(a);
     BN_free(two);
     BN_free(d1);
-    BN_free(d2);
     BN_free(q);
     BN_free(I);
     return -1;
@@ -52,9 +50,6 @@ static int initialize(void)
   BN_mod_inverse(a, a, q, ctx);
   BN_dec2bn(&d1, "-121665");
   BN_mul(d1, d1, a, ctx);
-
-  BN_dec2bn(&a, "-1");
-  BN_mul(d2, d1, a, ctx);
 
   BN_free(a);
 


### PR DESCRIPTION
The implementation of point addition and scalar multiplication on ed25519 made some computations twice and used recursive calls. This Pull Request simplifies the code, which makes `sys_cx_ecfp_generate_pair(CX_CURVE_Ed25519...)` as little bit faster.

I measured the performance gain by patching a test case:
```diff
diff --git a/tests/syscalls/test_ec.c b/tests/syscalls/test_ec.c
index da7e3887b2ed..f7802e14d105 100644
--- a/tests/syscalls/test_ec.c
+++ b/tests/syscalls/test_ec.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include <setjmp.h>
 // must come after setjmp.h
@@ -284,12 +285,13 @@ void test_eddsa_recover_x(void **state __attribute__((unused)))
 {
   cx_ecfp_private_key_t private_key;
   cx_ecfp_public_key_t pub1;
+  struct timeval start, stop;
 
   uint8_t secret_key[32];
   uint8_t buf[1 + 32 + 32];
 
   const eddsa_test_vector *tv;
-  size_t i;
+  size_t i, j;
 
   for (i = 0; i < ARRAY_SIZE(rfc8032_test_vectors); i++) {
     tv = &rfc8032_test_vectors[i];
@@ -299,8 +301,17 @@ void test_eddsa_recover_x(void **state __attribute__((unused)))
     assert_int_equal(sys_cx_ecfp_init_private_key(CX_CURVE_Ed25519, secret_key,
                                                   32, &private_key),
                      32);
-    assert_int_equal(
-        sys_cx_ecfp_generate_pair(CX_CURVE_Ed25519, &pub1, &private_key, 1), 0);
+    gettimeofday(&start, NULL);
+    for (j = 0; j < 10; j++) {
+      assert_int_equal(
+          sys_cx_ecfp_generate_pair(CX_CURVE_Ed25519, &pub1, &private_key, 1),
+          0);
+    }
+    gettimeofday(&stop, NULL);
+    uint64_t millisecs = (stop.tv_usec - start.tv_usec) / 1000 +
+                         (stop.tv_sec - start.tv_sec) * 1000;
+    fprintf(stderr, "TEST[%u]: %u gen pair in %llu millisecs\n", i, j,
+            millisecs);
     assert_int_equal(pub1.W_len, 1 + 32 + 32);
 
     buf[0] = 2;
```

Output before this PR:
```text
TEST[0]: 10 gen pair in 2189 millisecs
TEST[1]: 10 gen pair in 2262 millisecs
TEST[2]: 10 gen pair in 2219 millisecs
TEST[3]: 10 gen pair in 2253 millisecs
TEST[4]: 10 gen pair in 2233 millisecs
TEST[5]: 10 gen pair in 2368 millisecs
```

Output after this PR:
```text
TEST[0]: 10 gen pair in 2011 millisecs
TEST[1]: 10 gen pair in 2095 millisecs
TEST[2]: 10 gen pair in 2063 millisecs
TEST[3]: 10 gen pair in 2109 millisecs
TEST[4]: 10 gen pair in 2097 millisecs
TEST[5]: 10 gen pair in 2152 millisecs
```

So running 10 times `sys_cx_ecfp_generate_pair(CX_CURVE_Ed25519...)` went from 2254 milliseconds (in average) down to 2087 ms. This is a `(2254-2087)/2254 = 7.4%` performance gain :)