### PR TITLE
mcu/apdu: fix forwarding packets without SW

### DIFF
--- a/mcu/apdu.py
+++ b/mcu/apdu.py
@@ -78,7 +78,7 @@ class ApduClient:
 
         self.logger.info("< {}".format(packet.hex()))
 
-        size = len(packet) - 2
+        size = (len(packet) - 2) & 0xffffffff
         packet = size.to_bytes(4, 'big') + packet
         try:
             self.s.sendall(packet)


### PR DESCRIPTION
Some applications (like FIDO2/U2F) craft APDU responses with no status word. With makes `mcu/apdu.py` explodes with:

    OverflowError: can't convert negative int to unsigned

Wrap the computed `size` to an unsigned 32-bit value to avoid this.