### PR TITLE
launcher: map the launcher at a lower address to prevent int overflow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,5 +49,5 @@ add_dependencies(emu openssl)
 
 add_executable(launcher launcher.c)
 # ensure the loader .text section doesn't mess with cxlib
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Ttext-segment=0xff000000")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Ttext-segment=0xf0000000")
 target_link_libraries(launcher PRIVATE emu)


### PR DESCRIPTION
When using QEMU 5.2.0 (from Debian 11) or 6.0.0 (from Arch Linux), speculos fails to start, with:

    qemu-arm-static: /speculos/build/src/launcher: Error mapping file:
    Cannot allocate memory

This error comes from QEMU's loading of ELF files: https://github.com/qemu/qemu/blob/v5.2.0/linux-user/elfload.c#L2869

Using `qemu-arm-static -d trace:* build/src/launcher` to debug this issue leads to:

    203@1623857052.685085:target_mmap start=0xff000000 len=0x11aaa94
    prot=0x0 flags=0x4032 fd=-1 offset=0x0

As 0xff000000 + 0x11aaa94 = 0x1001aaa94 overflows the capacity of 32-bit integers, it is normal that QEMU fails to allocate memory. Fix this by moving the launcher to a lower address.