### PR TITLE
mcu/seproxyhal: ignore io_seproxyhal_request_mcu_status

### DIFF
--- a/mcu/seproxyhal.py
+++ b/mcu/seproxyhal.py
@@ -23,6 +23,7 @@ class SephTag(IntEnum):
     USB_CONFIG = 0x4f
     USB_EP_PREPARE = 0x50
 
+    REQUEST_STATUS = 0x52
     RAPDU = 0x53
     PRINTC_STATUS = 0x5f
 
@@ -307,6 +308,10 @@ class SeProxyHal:
             self.logger.warn("received tag SE_POWER_OFF, exiting")
             self._close(s, screen)
             raise ReadError("SE_POWER_OFF")
+
+        elif tag == SephTag.REQUEST_STATUS:
+            # Ignore calls to io_seproxyhal_request_mcu_status()
+            pass
 
         else:
             self.logger.error(f"unknown tag: {tag:#x}")


### PR DESCRIPTION
The U2F application calls `io_seproxyhal_request_mcu_status` (in https://github.com/LedgerHQ/app-u2f/blob/561adacce62082875e89f241acbcb59a3c14639e/src/main.c#L1871 ), which emits a `SEPROXYHAL_TAG_REQUEST_STATUS` packet (in https://github.com/LedgerHQ/nanos-secure-sdk/blob/2.0.0-1/src/os_io_seproxyhal.c#L124-L132 ).
Currently, this call makes speculos to stop immediately, with:

    seproxyhal: unknown tag: 0x52

Ignore `SEPROXYHAL_TAG_REQUEST_STATUS` packets, as they are not necessary for the app to operate correctly.