### PR TITLE
mcu: silence LGTM error about binding to 0.0.0.0

### DIFF
--- a/mcu/apdu.py
+++ b/mcu/apdu.py
@@ -14,7 +14,7 @@ class ApduServer:
     def __init__(self, host='127.0.0.1', port=9999, hid=False):
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.s.bind((host, port))
+        self.s.bind((host, port))  # lgtm [py/bind-socket-all-network-interfaces]
         self.s.listen()
 
         self.client = None


### PR DESCRIPTION
https://lgtm.com/ reports "'0.0.0.0' binds a socket to all interfaces." in:

    self.s.bind((host, port))

because `ApduServer` is only used with 0.0.0.0:

    apdu = apdu_server.ApduServer(host="0.0.0.0", port=args.apdu_port)

Like commit f2e0e0eac6f7 ("mcu: remove LGTM "'0.0.0.0' binds a socket to all interfaces" alerts"), add a comment to silence LGTM.