### PR TITLE
api: run Flask in development mode

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -14,6 +14,7 @@ import mcu.automation
 static_folder = pkg_resources.resource_filename(__name__, "/swagger")
 
 app = Flask(__name__, static_url_path="", static_folder=static_folder)
+app.env = "development"
 api = Api(app)
 automation_events = []
 

--- a/speculos.py
+++ b/speculos.py
@@ -318,8 +318,12 @@ if __name__ == '__main__':
     if api_enabled:
         app = api.create_app(screen, seph)
         # threaded must be set to allow serving requests along events streaming
-        api_thread = threading.Thread(target=lambda: app.run(host="0.0.0.0", port=args.api_port, threaded=True),
-                                      daemon=True)
+        api_thread = threading.Thread(
+            target=lambda: app.run(
+                host="0.0.0.0", port=args.api_port, threaded=True, use_reloader=False
+            ),
+            daemon=True,
+        )
         api_thread.start()
 
     screen.run()


### PR DESCRIPTION
Currently, launching Speculos leads to a big warning message:

     * Serving Flask app "api.api" (lazy loading)
     * Environment: production
       WARNING: This is a development server. Do not use it in a production deployment.
       Use a production WSGI server instead.

This is because Speculos uses the web server embedded in Flash, instead of a real web server (Apache, NGINX...) and a WSGI service.

Following https://flask.palletsprojects.com/en/2.0.x/config/ , enable *development* environment.

Moreover when running with `FLASK_DEBUG=on`, an exception is raised in werkzeug (the web server used by Flask):

      File "/usr/lib/python3/dist-packages/werkzeug/_reloader.py", line 330, in run_with_reloader
        signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
      File "/usr/lib/python3.9/signal.py", line 47, in signal
        handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
    ValueError: signal only works in main thread of the main interpreter

This is because Flask runs with a reloader by default. The documentation https://github.com/pallets/flask/blob/2.0.1/docs/debugging.rst specifies a parameter `use_reloader=False` to disable the reloader. This fixes the issue.