### PR TITLE
Add flask_restful in Speculos requirements

### DIFF
--- a/docs/installation/build.md
+++ b/docs/installation/build.md
@@ -7,7 +7,7 @@ sort: 1
 ## Requirements
 
 ```shell
-sudo apt install qemu-user-static python3-pyqt5 python3-construct python3-jsonschema python3-mnemonic python3-pyelftools gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch
+sudo apt install qemu-user-static python3-pyqt5 python3-construct python3-flask-restful python3-jsonschema python3-mnemonic python3-pyelftools gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch
 ```
 
 For optional VNC support, please also install `libvncserver-dev`:
@@ -15,7 +15,6 @@ For optional VNC support, please also install `libvncserver-dev`:
 ```shell
 sudo apt install libvncserver-dev
 ```
-
 
 ## Build
 


### PR DESCRIPTION
#170 adds a REST API that uses flask_restful.
This PR updates the documentation and adds python3-flask-restful in the requirements.