### PR TITLE
Fix screenshot race condition

### DIFF
--- a/mcu/display.py
+++ b/mcu/display.py
@@ -42,14 +42,17 @@ class Screenshot:
                 self.pixels[(x, y)] = 0x000000
 
     def update(self, pixels):
-        self.pixels.update(pixels)
+        # Don't call update, replace the object instead
+        self.pixels = {**self.pixels, **pixels}
 
     def get_image(self):
+        # Get the pixels object once, as it may be replaced during the loop.
+        pixels = self.pixels
         data = bytearray(self.width * self.height * 3)
         for y in range(0, self.height):
             for x in range(0, self.width):
                 pos = 3 * (y * self.width + x)
-                data[pos:pos + 3] = self.pixels[(x, y)].to_bytes(3, "big")
+                data[pos:pos + 3] = pixels[(x, y)].to_bytes(3, "big")
         return (self.width, self.height), bytes(data)
 
 


### PR DESCRIPTION
Screenshot API requests may return invalid images due to a race condition on the screenshot image update.
This happens frequently especially when recording a GIF.

Here is an example of invalid screenshot during a GIF recording:
![speculos](https://user-images.githubusercontent.com/43875454/123668971-eb764980-d83b-11eb-8b0a-55259332dc11.png)