### PR TITLE
docs: add cmake to the Linux build requirements

### DIFF
--- a/docs/installation/build.md
+++ b/docs/installation/build.md
@@ -6,8 +6,13 @@ sort: 1
 
 ## Requirements
 
+For Debian (version 10 "Buster" or later) and Ubuntu (version 18.04 or later):
+
 ```shell
-sudo apt install qemu-user-static python3-pyqt5 python3-construct python3-flask-restful python3-jsonschema python3-mnemonic python3-pyelftools gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch
+sudo apt install \
+    cmake gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch \
+    python3-pyqt5 python3-construct python3-flask-restful python3-jsonschema python3-mnemonic python3-pyelftools \
+    qemu-user-static
 ```
 
 For optional VNC support, please also install `libvncserver-dev`:


### PR DESCRIPTION
cmake is required to run the build commands.

While at it, split the long line in order to improve the rendered documentation on https://speculos.ledger.com/installation/build.html and document the supported Linux distributions on which the command line works. This command has been tested with containers `docker.io/library/debian:10-slim` and `docker.io/library/ubuntu:18.04`.