### PR TITLE
src/vnc: mark VNC Server sub-project as C-only

### DIFF
--- a/src/vnc/CMakeLists.txt
+++ b/src/vnc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(VncServer)
+project(VncServer C)
 
 add_compile_options(-Wall)
 


### PR DESCRIPTION
When trying to build speculos using `pip` in a minimal container, `cmake` complains about not being able to find a C++ compiler:

    cmake --build build
    [  1%] Creating directories for 'vnc_server'
    [  1%] No download step for 'vnc_server'
    [  2%] No update step for 'vnc_server'
    [  3%] No patch step for 'vnc_server'
    [  4%] Performing configure step for 'vnc_server'
    -- The C compiler identification is GNU 8.3.0
    -- The CXX compiler identification is unknown
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Check for working C compiler: /usr/bin/cc - skipped
    -- Detecting C compile features
    -- Detecting C compile features - done
    CMake Error at CMakeLists.txt:3 (project):
      No CMAKE_CXX_COMPILER could be found.

      Tell CMake where to find the compiler by setting either the environment
      variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
      to the compiler, or to the compiler name if it is in the PATH.

Having a C++ compiler is not required to build Speculos, but CMake did not know about this because no language was specified in the VNC Server's `CMakeLists.txt`. Adding a `C` in the right place fixes this issue.