### PR TITLE
tests/apps: make conftest more robust

### DIFF
--- a/tests/apps/conftest.py
+++ b/tests/apps/conftest.py
@@ -38,13 +38,18 @@ def list_apps_to_test(app_dir) -> List[AppInfo]:
     """
     # name example: nanos#btc#1.5#5b6693b8.elf
     app_regexp = re.compile(
-        r"(nanos|nanox|blue)#(.+)#([^#][\d\w\-.]+)#([a-f0-9]{8}).elf"
+        r"^(nanos|nanox|blue)#([^#]+)#([^#][\d\w\-.]+)#([a-f0-9]{8})\.elf$"
     )
     all_apps = []
     for filename in os.listdir(app_dir):
-        matching = re.match(app_regexp, filename)
-        if not matching or len(matching.groups()) != 4:
+        if "#" not in filename:
             continue
+        matching = re.match(app_regexp, filename)
+        if not matching:
+            pytest.fail(
+                f"An unexpected file was found in apps/, with a # but not matching the pattern: {filename!r}"
+            )
+        assert len(matching.groups()) == 4
 
         all_apps.append(
             AppInfo(
@@ -73,7 +78,7 @@ def pytest_generate_tests(metafunc):
         metafunc.cls.app_names, list
     ):
         pytest.fail(
-            "The TestClass {metafunc.cls} does not have a correct 'app_names' attribute. \n"
+            f"The TestClass {metafunc.cls} does not have a correct 'app_names' attribute.\n"
             "The 'app_names' attribute must contain a list of app names that will be"
             "tested by this test."
         )


### PR DESCRIPTION
The regular expression which was used to find applications in apps/ used
an unescaped dot in `.elf`. This matched any character instead of a dot,
which is a bug. Add a backslash character to fix this bug.

While at it, add `^` and `$` characters to the regular expression, and
use `[^#]+` to match the application name, as it is not allowed to
contain any `#` character.

While at it, make `list_apps_to_test` fail when it encounters a file in
`apps/` which does not match the regexp if it should. This helps
detecting possible issues with the regexp, if it is for example too
restrictive.

Last but not least, a `f` was missing when the error which produces the
message `"The TestClass {metafunc.cls} does not have a correct 'app_names' attribute."`
occurs. This makes pytest reports messages such as:

    tests/apps/conftest.py:78: in pytest_generate_tests
        pytest.fail(
    E   Failed: The TestClass {metafunc.cls} does not have a correct 'app_names' attribute.
    E   The 'app_names' attribute must contain a list of app names that will betested by this test.

Add the missing `f` to format `metafunc.cls` as intended.