### PR TITLE
Save caller try_context to avoid anarchic longjmps

### DIFF
--- a/src/bolos/os.c
+++ b/src/bolos/os.c
@@ -20,6 +20,7 @@
 struct libcall_s {
   struct app_s *app;
   struct sigcontext sigcontext;
+  try_context_t *trycontext;
 };
 
 static try_context_t *try_context;
@@ -103,6 +104,9 @@ unsigned long sys_os_lib_call(unsigned long *call_parameters)
     _exit(1);
   }
 
+  /* save current try_context of the caller */
+  libcalls[libcall_index].trycontext = try_context;
+
   /* save current app to restore it later */
   save_current_context(&libcalls[libcall_index].sigcontext);
   libcalls[libcall_index].app = get_current_app();
@@ -169,6 +173,9 @@ unsigned long sys_os_lib_end(void)
   }
 
   replace_current_context(&libcalls[libcall_index].sigcontext);
+
+  /* restore try_context of the caller */
+  try_context = libcalls[libcall_index].trycontext;
 
   return 0;
 }


### PR DESCRIPTION
In the event of a `os_lib_call`, the caller `try_context` can be erased by the `try_context` of the callee as its main is likely to be in a `TRY/CATCH` block. After returning to the caller with a `os_lib_end` if the call triggers an exception of some sorts (`THROW`), the `longjump` performed to branch to the `try_context` stack pointer uses a wrong address (the one of the stack pointer's callee's `try_context`) This commit aims at saving/restoring the caller's context after a call to `os_lib_call` to prevent the issue