### PR TITLE
vnc_server: allow pselect6 syscall

### DIFF
--- a/src/vnc/vnc_server.c
+++ b/src/vnc/vnc_server.c
@@ -214,6 +214,7 @@ static int load_seccomp(void)
     ALLOW_SYSCALL(mmap),
     ALLOW_SYSCALL(munmap),
     ALLOW_SYSCALL(prlimit64),
+    ALLOW_SYSCALL(pselect6),
     ALLOW_SYSCALL(read),
     ALLOW_SYSCALL(recvfrom),
     ALLOW_SYSCALL(rt_sigaction),


### PR DESCRIPTION
On Ubuntu 21.04, `select()` now uses `pselect6` syscall. This makes `vnc_server` crash because of its seccomp filter. `strace` shows:

    bind(4, {sa_family=AF_INET6, sin6_port=htons(5900),
    sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "::", &sin6_addr),
    sin6_scope_id=0}, 28) = 0

    listen(4, 32)                           = 0

    rt_sigaction(SIGPIPE, {sa_handler=SIG_IGN, sa_mask=[PIPE],
    sa_flags=SA_RESTORER|SA_RESTART, sa_restorer=0x7f559ea63040},
    {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0

    pselect6(5, [0 3 4], NULL, NULL, {tv_sec=0, tv_nsec=5000000},
    NULL <unfinished ...>) = ?

    +++ killed by SIGSYS (core dumped) +++

Fix this by allowing the syscall.