### PR TITLE
docs/installation/build: install python3-pil and python3-requests too

### DIFF
--- a/docs/installation/build.md
+++ b/docs/installation/build.md
@@ -11,7 +11,8 @@ For Debian (version 10 "Buster" or later) and Ubuntu (version 18.04 or later):
 ```shell
 sudo apt install \
     cmake gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch \
-    python3-pyqt5 python3-construct python3-flask-restful python3-jsonschema python3-mnemonic python3-pyelftools \
+    python3-pyqt5 python3-construct python3-flask-restful python3-jsonschema \
+    python3-mnemonic python3-pil python3-pyelftools python3-requests \
     qemu-user-static
 ```
 


### PR DESCRIPTION
Since commit 0c1bbcf00b30 ("add a REST API server") Speculos depends on
PIL or Pillow to provide a module for `from PIL import Image`. Moreover
it uses `requests` to interact with the embedded HTTP server. Update
the dependencies command line accordingly.

NB. The Python dependencies used by the Docker container are listed in
`Pipfile` and were updated in commit 1ecedc8eefe6 ("update pip files").