### PR TITLE
speculos/api: plug the API to the notifiers mechanism

### DIFF
--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -68,6 +68,9 @@ class ApiRunner:
         try:
             # threaded must be set to allow serving requests along events streaming
             app.run(host="0.0.0.0", port=self.api_port, threaded=True, use_reloader=False)
+        except Exception as exc:
+            app.logger.error("an exception occurred in the Flask API server: %s", exc)
+            raise
         finally:
             self._notify_exit.close()
 
@@ -75,7 +78,7 @@ class ApiRunner:
         global screen, seph
         screen, seph = screen_, seph_
         seph.apdu_callbacks.append(apdu.seph_apdu_callback)
-        api_thread = threading.Thread(target=self._run, daemon=True)
+        api_thread = threading.Thread(target=self._run, name="API-server", daemon=True)
         api_thread.start()
 
 

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -313,20 +313,16 @@ def main():
     if args.xy:
         x, y = (int(i) for i in args.xy.split('x'))
 
+    apirun = None
+    if api_enabled:
+        apirun = api.ApiRunner(args.api_port)
+
     display_args = display.DisplayArgs(args.color, args.model, args.ontop, rendering, args.keymap, zoom, x, y)
-    server_args = display.ServerArgs(apdu, button, finger, seph, vnc)
+    server_args = display.ServerArgs(apdu, apirun, button, finger, seph, vnc)
     screen = Screen(display_args, server_args)
 
     if api_enabled:
-        app = api.create_app(screen, seph)
-        # threaded must be set to allow serving requests along events streaming
-        api_thread = threading.Thread(
-            target=lambda: app.run(
-                host="0.0.0.0", port=args.api_port, threaded=True, use_reloader=False
-            ),
-            daemon=True,
-        )
-        api_thread.start()
+        apirun.start_server_thread(screen, seph)
 
     screen.run()
 

--- a/speculos/mcu/display.py
+++ b/speculos/mcu/display.py
@@ -11,7 +11,7 @@ from .vnc import VNC
 Server = Union[ApduServer, FakeButton, FakeFinger, SeProxyHal, VNC]
 
 DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size x y")
-ServerArgs = namedtuple("ServerArgs", "apdu button finger seph vnc")
+ServerArgs = namedtuple("ServerArgs", "apdu apirun button finger seph vnc")
 
 Model = namedtuple('Model', 'name screen_size box_position box_size')
 MODELS = {


### PR DESCRIPTION
*This PR depends on https://github.com/LedgerHQ/speculos/pull/212 as this works was done after it.*

When the API server fails to start, for example when there is already a server bound to TCP port 5000, Speculos continued to run. This is because the Flask web server was launched in a separate thread and propagating a failure is not straightforward.

Introduce a new `socketpair` to signal Speculos' main event loop that the API server stopped and that Speculos should exits.