### PR TITLE
Publish Speculos on TestPyPI in the CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Clone
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Lint C code
       uses: DoozyX/clang-format-lint-action@v0.11

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -63,6 +63,33 @@ jobs:
         ./venv-test/bin/pip install .
         ./venv-test/bin/speculos --help
 
+    # Use commands from https://packaging.python.org/tutorials/packaging-projects/
+    # to build the Speculos package, but using a dedicated virtual environment
+    # to be cleanly upgrade Python packages.
+    - name: Build Speculos python package
+      run: |
+        if [ -e dist ] ; then
+          echo >&2 "Error: dist/ directory already exists and this is unexpected. Refusing to build new packages."
+          exit 1
+        fi
+        sed -i 's;docs/screenshot-api-nanos-btc\.png;https://raw.githubusercontent.com/LedgerHQ/speculos/master/docs/screenshot-api-nanos-btc.png;' README.md
+        ./tools/update_setup_version_from_git.sh
+        python3 -m venv venv-build
+        ./venv-build/bin/pip install --upgrade pip build twine
+        ./venv-build/bin/python -m build
+        ./venv-build/bin/python -m twine check dist/*
+
+    # TEST_PYPI_API_TOKEN is an API token created on
+    # https://test.pypi.org/manage/account/#api-tokens with restriction to speculos project
+    - name: Publish Python package to test.pypi.org
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: |
+        ./venv-build/bin/python -m twine upload --repository testpypi dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        TWINE_NON_INTERACTIVE: 1
+
     - name: Build and publish to GitHub Packages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v1


### PR DESCRIPTION
Use commands from https://packaging.python.org/tutorials/packaging-projects/ to build the Python package and push it to TestPyPI at each commit on `master`.
    
This requires the C code of Speculos to be part of the source tarball ("sdist"). Modify `MANIFEST.in` accordingly.
As this also requires that `setup.py` no longer builds the C tests, this PR depends on https://github.com/LedgerHQ/speculos/pull/219.