### PR TITLE
Enable building Speculos with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,22 +59,45 @@ else()
   message(STATUS "Building OpenSSL and cmocka...")
   set(INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/install)
 
+  set(OPENSSL_CFLAGS "${CMAKE_C_FLAGS}")
+  get_directory_property(compile_options COMPILE_OPTIONS)
+  foreach (opt ${compile_options})
+    string(APPEND OPENSSL_CFLAGS " ${opt}")
+  endforeach ()
+  if (CMAKE_C_COMPILER_TARGET)
+    string(APPEND OPENSSL_CFLAGS " --target=${CMAKE_C_COMPILER_TARGET}")
+  endif ()
+  if (CMAKE_SYSROOT)
+    string(APPEND OPENSSL_CFLAGS " -isystem${CMAKE_SYSROOT}/include")
+  endif ()
+  string(APPEND OPENSSL_CFLAGS " -Wno-unused-parameter -Wno-missing-field-initializers")
+
   ExternalProject_Add(
     openssl
     URL https://www.openssl.org/source/openssl-1.1.1k.tar.gz
     URL_HASH SHA256=892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
-    CONFIGURE_COMMAND ./Configure --cross-compile-prefix=arm-linux-gnueabihf- no-afalgeng no-aria no-asan no-asm no-async no-autoalginit no-autoerrinit no-autoload-config no-bf no-buildtest-c++ no-camellia no-capieng no-cast no-chacha no-cmac no-cms no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-ct no-deprecated no-des no-devcryptoeng no-dgram no-dh no-dsa no-dso no-dtls no-ec2m no-ecdh no-egd no-engine no-err no-external-tests no-filenames no-fuzz-afl no-fuzz-libfuzzer no-gost no-heartbeats no-hw no-idea no-makedepend no-md2 no-md4 no-mdc2 no-msan no-multiblock no-nextprotoneg no-ocb no-ocsp no-pinshared no-poly1305 no-posix-io no-psk no-rc2 no-rc4 no-rc5 no-rdrand no-rfc3779 no-scrypt no-sctp no-seed no-shared no-siphash no-sm2 no-sm3 no-sm4 no-sock no-srp no-srtp no-sse2 no-ssl no-ssl3-method no-ssl-trace no-stdio no-tests no-threads no-tls no-ts no-ubsan no-ui-console no-unit-test no-whirlpool no-zlib no-zlib-dynamic linux-armv4 --prefix=${INSTALL_DIR}
-    BUILD_COMMAND make CFLAGS=-mthumb
+    CONFIGURE_COMMAND ./Configure "CC=${CMAKE_C_COMPILER}" "CFLAGS=${OPENSSL_CFLAGS}" no-afalgeng no-aria no-asan no-asm no-async no-autoalginit no-autoerrinit no-autoload-config no-bf no-buildtest-c++ no-camellia no-capieng no-cast no-chacha no-cmac no-cms no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-ct no-deprecated no-des no-devcryptoeng no-dgram no-dh no-dsa no-dso no-dtls no-ec2m no-ecdh no-egd no-engine no-err no-external-tests no-filenames no-fuzz-afl no-fuzz-libfuzzer no-gost no-heartbeats no-hw no-idea no-makedepend no-md2 no-md4 no-mdc2 no-msan no-multiblock no-nextprotoneg no-ocb no-ocsp no-pinshared no-poly1305 no-posix-io no-psk no-rc2 no-rc4 no-rc5 no-rdrand no-rfc3779 no-scrypt no-sctp no-seed no-shared no-siphash no-sm2 no-sm3 no-sm4 no-sock no-srp no-srtp no-sse2 no-ssl no-ssl3-method no-ssl-trace no-stdio no-tests no-threads no-tls no-ts no-ubsan no-ui-console no-unit-test no-whirlpool no-zlib no-zlib-dynamic linux-armv4 --prefix=${INSTALL_DIR}
+    BUILD_COMMAND make
     INSTALL_COMMAND make install_sw
     BUILD_IN_SOURCE 1
   )
 
   if (BUILD_TESTING)
+    set(CMOCKA_CMAKE_ARGS
+      -DWITH_STATIC_LIB=true
+      "-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}"
+      "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+      "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+    )
+    if (CMAKE_TOOLCHAIN_FILE)
+      get_filename_component(abs_cmake_toolchain_file "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE)
+      list(APPEND CMOCKA_CMAKE_ARGS "-DCMAKE_TOOLCHAIN_FILE=${abs_cmake_toolchain_file}")
+    endif ()
     ExternalProject_Add(cmocka
       PREFIX ${CMAKE_CURRENT_BINARY_DIR}/cmocka
       URL https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz
       URL_HASH SHA256=f0ccd8242d55e2fd74b16ba518359151f6f8383ff8aef4976e48393f77bba8b6
-      CMAKE_ARGS += -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_C_FLAGS=-mthumb -DWITH_STATIC_LIB=true -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+      CMAKE_ARGS ${CMOCKA_CMAKE_ARGS}
     )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,15 @@ project(Speculos C)
 include(CTest)
 include(ExternalProject)
 
-set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
-set(CMAKE_EXE_LINKER_FLAGS -static)
+if (CMAKE_TOOLCHAIN_FILE)
+  message(STATUS "Using toolchain ${CMAKE_TOOLCHAIN_FILE}")
+else ()
+  # By default, use gcc cross-compiler for ARM-Thumb
+  set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+  add_compile_options(-mthumb)
+  message(STATUS "Using default compiler ${CMAKE_C_COMPILER}")
+endif ()
+add_link_options(-static)
 
 enable_testing()
 
@@ -22,7 +29,7 @@ execute_process(
     OUTPUT_VARIABLE GIT_REVISION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-add_compile_options(-mthumb -W -Wall -fPIC)
+add_compile_options(-W -Wall -fPIC)
 add_definitions(-DOS_LITTLE_ENDIAN -DNATIVE_64BITS -DGIT_REVISION=\"${GIT_REVISION}\")
 
 option(

--- a/clang-armv7m.cmake
+++ b/clang-armv7m.cmake
@@ -1,0 +1,20 @@
+# cmake-toolchain configuration to build with clang on Debian and Ubuntu
+#
+# Usage:
+#
+#   cmake -DCMAKE_TOOLCHAIN_FILE=clang-armv7m.cmake -Bbuild -H. && cmake --build build
+#
+# Documentation: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET armv7m-linux-gnueabihf)
+
+# Use files installed by libc6-dev-armhf-cross
+# (This adds /usr/arm-linux-gnueabihf/include to CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES)
+set(CMAKE_SYSROOT /usr/arm-linux-gnueabihf)
+
+# Use LLVM linker to link ARM code, as using the system "ld" fails on Ubuntu with x86-64
+add_link_options(-fuse-ld=lld)

--- a/gcc-arm.cmake
+++ b/gcc-arm.cmake
@@ -1,0 +1,14 @@
+# cmake-toolchain configuration to build with gcc on Debian and Ubuntu
+#
+# Usage:
+#
+#   cmake -DCMAKE_TOOLCHAIN_FILE=gcc-arm.cmake -Bbuild -H. && cmake --build build
+#
+# Documentation: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+
+set(CMAKE_C_FLAGS "-mthumb" CACHE STRING "" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,5 +49,13 @@ add_dependencies(emu openssl)
 
 add_executable(launcher launcher.c)
 # ensure the loader .text section doesn't mess with cxlib
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Ttext-segment=0xf0000000")
+if (CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+  # Option for clang
+  set_property(TARGET launcher APPEND PROPERTY LINK_OPTIONS "LINKER:--image-base=0xf0000000")
+elseif (CMAKE_C_COMPILER_ID MATCHES "GNU")
+  # Option for gcc
+  set_property(TARGET launcher APPEND PROPERTY LINK_OPTIONS "LINKER:-Ttext-segment=0xf0000000")
+else ()
+  message(FATAL_ERROR "Unable to identify the compiler!")
+endif ()
 target_link_libraries(launcher PRIVATE emu)


### PR DESCRIPTION
Some time ago I wanted to build Speculos with `clang` in order to see whether some clang-specific warnings triggered with Speculos's C code. It was quite difficult because the current cmake configuration expects to be using `arm-linux-gnueabihf-gcc` in several places.

This Pull Request:

* enables using a toolchain file as documented in https://cmake.org/cmake/help/v3.21/manual/cmake-toolchains.7.html#cross-compiling ;
* introduces `clang-armv7m.cmake` and `gcc-arm.cmake` which can be used to build Speculos (usage is documented as the beginning of these files) ;
* propagates the toolchain configuration in the external sub-projects (OpenSSL and cmocka) ;
* makes the build configuration compatibles with clang (clang does not know about `-mthumb` and `-Ttext-segment`) ;
* ... while keeping the usual build command `cmake -Bbuild -H. && cmake --build build` working (it detects that no toolchain was selected and falls back to the current configuration with `arm-linux-gnueabihf-gcc`).

For now, I do not know whether there is an interest of being able to build with clang other than "this compiler has a different set of warning flags than gcc" and "it seems nice to be *portable* in some way".