### PR TITLE
Introduce version 0.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
+include CMakeLists.txt
+recursive-include sdk *.h
+recursive-include src *.c *.h *.txt
 include speculos/api/resources/*.schema
 include speculos/api/static/index.html
 include speculos/api/static/swagger/*.css

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     name="speculos",
     author="Ledger",
     author_email="hello@ledger.fr",
-    version="0.0.1",
+    version="0.1.0",
     url="https://github.com/LedgerHQ/speculos",
     python_requires=">=3.6.0",
     description="Ledger Blue and Nano S/X application emulator",

--- a/tools/update_setup_version_from_git.sh
+++ b/tools/update_setup_version_from_git.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Update the version field of Speculos python package, in setup.py.
+#
+# This script is intended to be used before creating a Python package, in order
+# to create a source tarball ("sdist package") with a version which has been
+# defined using the number of git commits since the last tag, without requiring
+# to have the git repository in the package.
+#
+# Git tags are expected to be "major.minor", such as "0.1".
+
+set -eu
+cd "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+LAST_TAG="$(git describe --tags --abbrev=0)"
+COUNT="$(git rev-list --count "${LAST_TAG}..HEAD")"
+VERSION="${LAST_TAG}.${COUNT}"
+
+sed 's/^\( *version=\)"[^"]*"/\1"'"${VERSION}"'"/' -i setup.py


### PR DESCRIPTION
This prepares the publication of Speculos package on PyPI and TestPyPI. The idea is to tag the merge commit of this PR with `0.1`. Then the version of each merge commit of the master branch can be computed with:

```sh
LAST_TAG="$(git describe --tags --abbrev=0)"
COUNT="$(git rev-list --count "${LAST_TAG}..HEAD")"
VERSION="${LAST_TAG}.${COUNT}"
```

(For example the merge commit 10 commits after tag `0.1` would be version `0.1.10`.

Introduce `tools/update_setup_version_from_git.sh` to do this in `setup.py`. This file may then be called from GitHub Action to update `setup.py` before creating the Python package (I will update https://github.com/LedgerHQ/speculos/pull/220 accordingly once this PR is discussed/merged).