### PR TITLE
src/emulate_2.0: remove retid variable

### DIFF
--- a/src/emulate_2.0.c
+++ b/src/emulate_2.0.c
@@ -14,8 +14,6 @@
 int emulate_2_0(unsigned long syscall, unsigned long *parameters,
                 unsigned long *ret, bool verbose)
 {
-  int retid;
-
   switch (syscall) {
     /* clang-format off */
 
@@ -278,8 +276,9 @@ int emulate_2_0(unsigned long syscall, unsigned long *parameters,
              unsigned char *, privateKey);
 
   default:
-    retid = emulate_common(syscall, parameters, ret, verbose);
+    emulate_common(syscall, parameters, ret, verbose);
     break;
   }
-  return retid;
+  /* retid is no longer used in SDK 2.0 */
+  return 0;
 }


### PR DESCRIPTION
In SDK 2.0, the retid mechanism is no longer used. But `emulate_2_0` still used a local variable, which is not initialized. This leads to clang reporting many warnings such as:

    speculos/src/emulate_2.0.c:180:5: warning: variable 'retid' is used
    uninitialized whenever switch case is taken [-Wsometimes-uninitialized]
        SYSCALL3(cx_bn_mod_u32_invert, "(%u, %u, %u)", uint32_t, r, uint32_t, a,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    speculos/src/emulate.h:231:8: note: expanded from macro 'SYSCALL3'
      case SYSCALL_##_name##_ID_IN: {                                              \
           ^~~~~~~~~~~~~~~~~~~~~~~
    <scratch space>:118:1: note: expanded from here
    SYSCALL_cx_bn_mod_u32_invert_ID_IN
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix this by removing `retid` from `emulate_2_0`.