### PR TITLE
Execute speculos with python -m

### DIFF
--- a/speculos/__main__.py
+++ b/speculos/__main__.py
@@ -1,0 +1,5 @@
+from . import main
+
+
+if __name__ == "__main__":
+    main.main(prog="speculos")

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -156,7 +156,7 @@ def setup_logging(args):
             sys.exit(1)
 
 
-def main():
+def main(prog=None):
     parser = argparse.ArgumentParser(description='Emulate Ledger Nano/Blue apps.')
     parser.add_argument('app.elf', type=str, help='application path')
     parser.add_argument('--automation', type=str, help='Load a JSON document automating actions (prefix with "file:" '
@@ -200,6 +200,8 @@ def main():
     group.add_argument('--progressive', action='store_true', help='Enable step-by-step rendering of graphical elements')
     group.add_argument('--zoom', help='Display pixel size.', type=int, choices=range(1, 11))
 
+    if prog:
+        parser.prog = prog
     args = parser.parse_args()
     args.model.lower()
 

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -327,7 +327,3 @@ def main():
     screen.run()
 
     s2.close()
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Currently it is possible to run Speculos with `python -m speculos.main`. This is not very intuitive, and leads to a warning:

```text
/usr/local/lib/python3.8/runpy.py:127: RuntimeWarning: 'speculos.main' found in sys.modules after import of
package 'speculos', but prior to execution of 'speculos.main'; this may result in unpredictable behaviour
```

https://github.com/LedgerHQ/speculos/pull/229 fixed this by removing the `from . import main` from `__init__.py` but this is problematic: even though `import speculos.main ; speculos.main.main()` still works, `import speculos ; speculos.main.main()` does not.

This PR fixes this issue in a cleaner way, by introducing a `__main__.py` file in `speculos/`. While at it, it removes the execution ability from `main.py`.