### PR TITLE
Fix event stream

### DIFF
--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -153,8 +153,10 @@ class EventClient:
 
                 while self.events:
                     event = self.events.pop(0)
-                    data = json.dumps(event).encode()
-                    yield data + b"\n"
+                    data = json.dumps(event)
+                    # Format the event as specified in the specification:
+                    # https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
+                    yield f"data: {data}\n\n".encode()
         finally:
             events.remove_client(self)
 

--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -256,7 +256,9 @@ class Screenshot(Resource):
         image = Image.frombytes("RGB", screen_size, data)
         iobytes = io.BytesIO()
         image.save(iobytes, format="PNG")
-        return Response(iobytes.getvalue(), mimetype="image/png")
+        response = Response(iobytes.getvalue(), mimetype="image/png")
+        response.headers.add("Cache-control", "no-cache,no-store")
+        return response
 
 
 class Swagger(Resource):

--- a/speculos/api/static/index.html
+++ b/speculos/api/static/index.html
@@ -191,7 +191,13 @@ function send_apdu() {
 
 function refresh_screen() {
   var element = document.getElementById("screenshot");
-  element.src = "/screenshot";
+  /* 
+   * A new event might be received while the current request to /screenshot
+   * isn't finished. The browser doesn't make a new request and the resulting
+   * screenshot is outdated. Appending Date.now() forces the browser to cancel
+   * the current request and make a new one.
+   */
+  element.src = "/screenshot?force=" + Date.now();
 }
 
 function stream_events() {

--- a/speculos/api/static/index.html
+++ b/speculos/api/static/index.html
@@ -191,9 +191,7 @@ function send_apdu() {
 
 function refresh_screen() {
   var element = document.getElementById("screenshot");
-  element.src = "/screenshot?nocache=" + Date.now();
-  element.width = element.naturalWidth * 2;
-  element.height = element.naturalHeight * 2;
+  element.src = "/screenshot";
 }
 
 function stream_events() {
@@ -231,7 +229,14 @@ function on_keydown(e) {
   }
 }
 
+function zoom_screenshot() {
+  var element = document.getElementById("screenshot");
+  element.width = element.naturalWidth * 2;
+  element.height = element.naturalHeight * 2;
+}
+
 function main() {
+  zoom_screenshot();
   refresh_screen();
   stream_events();
   document.onkeydown = on_keydown;

--- a/speculos/api/static/index.html
+++ b/speculos/api/static/index.html
@@ -195,18 +195,13 @@ function refresh_screen() {
 }
 
 function stream_events() {
-  var http = new XMLHttpRequest();
-  http.open("GET", "/events?stream=true", true);
-  http.onreadystatechange = function() {
-    if (http.readyState == 3) {
-      refresh_screen();
-      var data = http.response.substr(http.seenBytes);
-      var element = document.getElementById("events");
-      element.value += data;
-      element.scrollTop = element.scrollHeight;
-    }
-  }
-  http.send();
+  var source = new EventSource('/events?stream=true');
+  var element = document.getElementById("events");
+  source.onmessage = function (event) {
+    refresh_screen();
+    element.value += event.data + "\n";
+    element.scrollTop = element.scrollHeight;
+  };
 }
 
 function on_keydown(e) {


### PR DESCRIPTION
Server-Sent Events (SSE) enables a client to receive automatic updates from a
server via an HTTP connection. It is now part of HTML5 since a few years and
supported by all browsers but IE:

- https://www.w3.org/TR/eventsource/
- https://html.spec.whatwg.org/multipage/server-sent-events.html

If fixes a bug where some events were received twice by the web page on Chrome
and Firefox.