### PR TITLE
tools/update_setup_version_from_git: no longer rely on git tag to modify the version

### DIFF
--- a/tools/update_setup_version_from_git.sh
+++ b/tools/update_setup_version_from_git.sh
@@ -3,16 +3,21 @@
 #
 # This script is intended to be used before creating a Python package, in order
 # to create a source tarball ("sdist package") with a version which has been
-# defined using the number of git commits since the last tag, without requiring
-# to have the git repository in the package.
+# defined using the number of git commits since the last time the package
+# version was modified in setup.py, without requiring to have the git repository
+# in the package.
 #
 # Git tags are expected to be "major.minor", such as "0.1".
 
 set -eu
 cd "$(dirname -- "${BASH_SOURCE[0]}")/.."
 
-LAST_TAG="$(git describe --tags --abbrev=0)"
-COUNT="$(git rev-list --count "${LAST_TAG}..HEAD")"
-VERSION="${LAST_TAG}.${COUNT}"
+VERSION_LINE="$(git grep -h --line-number '^    version=".*",$' setup.py | cut -d : -f 1)"
+LAST_CHANGE="$(git blame --abbrev=40 -L"${VERSION_LINE}",+1 HEAD setup.py | cut -d ' ' -f 1)"
+COUNT="$(git rev-list --count "${LAST_CHANGE}..HEAD")"
 
-sed 's/^\( *version=\)"[^"]*"/\1"'"${VERSION}"'"/' -i setup.py
+sed 's/^\(    version=\)"\([0-9]\+\.[0-9]\+\)\.[0-9]\+"/\1"\2.'"${COUNT}"'"/' -i setup.py
+
+# Display the new version
+echo 'Changed setup.py:'
+git grep -h '^    version=".*",$' setup.py


### PR DESCRIPTION
As Speculos git repository does not use tags currently, the reference of the version of the Python package is `setup.py`.

Change the way versions are computed so that it is `x.y.z` where the `setup.py` in git contains `x.y.0` and `z` is computed by counting the number of commits since the last change of the version line.

Suggested-in: https://github.com/LedgerHQ/speculos/issues/230