### PR TITLE
Added 'data' argument to ApduException; made args mandatory

### DIFF
--- a/speculos/client.py
+++ b/speculos/client.py
@@ -14,9 +14,10 @@ logger.setLevel(logging.INFO)
 
 
 class ApduException(Exception):
-    def __init__(self, sw: int = 0x6F00) -> None:
+    def __init__(self, sw: int, data: bytes) -> None:
         super().__init__(f"Exception: invalid status 0x{sw:x}")
         self.sw = sw
+        self.data = data
 
 
 class ClientException(Exception):
@@ -38,7 +39,7 @@ class ApduResponse:
         check_status_code(self.response, "/apdu")
         data, status = split_apdu(bytes.fromhex(self.response.json()["data"]))
         if status != 0x9000:
-            raise ApduException(status)
+            raise ApduException(status, data)
         return data
 
 


### PR DESCRIPTION
The ApduException class is missing information about the returned APDU data. This PR adds it to the constructor in order to enable handling the error in a more precise way (in my case, I return a special SW that is not an error, but rather a request for the client side; therefore, it is crucial to have access to the apdu data).