### PR TITLE
remove LGTM alert

### DIFF
--- a/speculos/mcu/automation.py
+++ b/speculos/mcu/automation.py
@@ -21,7 +21,7 @@ class Automation:
 
         if document.startswith("file:"):
             path = document[5:]
-            with open(path) as fp:
+            with open(path) as fp:  # lgtm [py/path-injection]
                 self.json = json.load(fp)
         else:
             self.json = json.loads(document)


### PR DESCRIPTION
  This path depends on a user-provided value.
  This alert was introduced in0c1bbcf3 months ago in/mcu/automation.py

The path comes from the command-line and that's expected.