### PR TITLE
Clean/api globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ build/
 core
 /speculos/resources/launcher
 /speculos/resources/vnc_server
+
+# python
+*.pyc
+dist/
+*egg-info

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/speculos/__init__.py
+++ b/speculos/__init__.py
@@ -1,4 +1,3 @@
 from . import api  # noqa: F401
 from . import client  # noqa: F401
 from . import mcu  # noqa: F401
-from . import main  # noqa: F401

--- a/speculos/api/__init__.py
+++ b/speculos/api/__init__.py
@@ -1,0 +1,2 @@
+from .api import ApiRunner # noqa: F401
+from .events import events # noqa: F401

--- a/speculos/api/__init__.py
+++ b/speculos/api/__init__.py
@@ -1,2 +1,2 @@
 from .api import ApiRunner # noqa: F401
-from .events import events # noqa: F401
+from .events import EventsBroadcaster # noqa: F401

--- a/speculos/api/__init__.py
+++ b/speculos/api/__init__.py
@@ -1,2 +1,2 @@
-from .api import ApiRunner # noqa: F401
-from .events import EventsBroadcaster # noqa: F401
+from .api import ApiRunner  # noqa: F401
+from .events import EventsBroadcaster  # noqa: F401

--- a/speculos/api/apdu.py
+++ b/speculos/api/apdu.py
@@ -48,7 +48,6 @@ class APDU(SephResource):
         super().__init__(*args, **kwargs)
         self._bridge = APDUBridge(self.seph)
 
-
     def post(self):
         args = request.get_json(force=True)
         try:

--- a/speculos/api/apdu.py
+++ b/speculos/api/apdu.py
@@ -1,0 +1,60 @@
+import json
+import threading
+import jsonschema
+from flask import stream_with_context, Response, request
+from typing import Generator, Optional
+
+from ..mcu.seproxyhal import SeProxyHal
+from .helpers import load_json_schema
+from .restful import SephResource
+
+
+class APDUBridge:
+    def __init__(self, seph: SeProxyHal):
+        # We want to be notified when APDU response is transmitted from the SE
+        self.endpoint_lock = threading.Lock()
+        self.response_condition = threading.Condition()
+        self._seph = seph
+        self._seph.apdu_callbacks.append(self.seph_apdu_callback)
+        self.response: Optional[bytes]
+
+    def exchange(self, data: bytes) -> Generator[bytes, None, None]:
+        # force headers to be sent
+        yield b""
+
+        with self.endpoint_lock:  # Lock for a command/response for one client
+            with self.response_condition:
+                self.response = None
+            self._seph.to_app(data)
+            with self.response_condition:
+                while self.response is None:
+                    self.response_condition.wait()
+            yield json.dumps({"data": self.response.hex()}).encode()
+
+    def seph_apdu_callback(self, data: bytes):
+        """
+        Called by seph when data is transmitted by the SE. That data should
+        be the response to a prior APDU request
+        """
+        with self.response_condition:
+            self.response = data
+            self.response_condition.notify()
+
+
+class APDU(SephResource):
+    schema = load_json_schema("apdu.schema")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bridge = APDUBridge(self.seph)
+
+
+    def post(self):
+        args = request.get_json(force=True)
+        try:
+            jsonschema.validate(instance=args, schema=self.schema)
+        except jsonschema.exceptions.ValidationError as e:
+            return {"error": f"{e}"}, 400
+
+        data = bytes.fromhex(args.get("data"))
+        return Response(stream_with_context(self._bridge.exchange(data)), content_type="application/json")

--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -20,13 +20,13 @@ from .web_interface import WebInterface
 class ApiRunner:
     """Run the Speculos API server, with a notification when it stops"""
     def __init__(self, api_port: int) -> None:
-        self._app : Optional[Flask] = None
+        self._app: Optional[Flask] = None
         # self.s is used by Screen.add_notifier. Closing self._notify_exit
         # signals it that the API is no longer running.
-        self.s : socket.socket
-        self._notify_exit : socket.socket
+        self.s: socket.socket
+        self._notify_exit: socket.socket
         self.s, self._notify_exit = socket.socketpair()
-        self.api_port : int = api_port
+        self.api_port: int = api_port
 
     def can_read(self, s: int, screen) -> None:
         assert s == self.s.fileno()

--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -1,63 +1,32 @@
-from flask import Flask, request, stream_with_context, Response
-from flask_restful import inputs, reqparse, Resource, Api
-import json
-import jsonschema
-import io
-import os.path
-from PIL import Image
-import pkg_resources
 import socket
 import threading
-import time
-from typing import Generator
+import pkg_resources
+from typing import Dict, Optional
+from flask import Flask
+from flask_restful import Api
 
-from ..mcu import automation as mcu_automation
 from ..mcu.readerror import ReadError
-
-
-static_folder = pkg_resources.resource_filename(__name__, "/static")
-
-app = Flask(__name__, static_url_path="", static_folder=static_folder)
-app.env = "development"
-api = Api(app)
-automation_events = []
-
-
-class EventsBroadcaster:
-    """This used to be the 'Automation Server'."""
-
-    def __init__(self):
-        self.clients = []
-        self.events = []
-        self.condition = threading.Condition()
-
-    def add_client(self, client):
-        app.logger.debug("events: new client")
-        self.clients.append(client)
-
-    def remove_client(self, client):
-        app.logger.debug("events: client exited")
-        self.clients.remove(client)
-
-    def broadcast(self, event):
-        app.logger.debug(f"events: broadcasting {event} to ({len(self.clients)}) client(s)")
-        self.events.append(event)
-        for client in self.clients:
-            client.send_screen_event(event)
-        with self.condition:
-            self.condition.notify_all()
-
-
-events = EventsBroadcaster()
+from ..mcu.seproxyhal import SeProxyHal
+from .apdu import APDU
+from .automation import Automation
+from .button import Button
+from .events import Events
+from .finger import Finger
+from .screenshot import Screenshot
+from .swagger import Swagger
+from .web_interface import WebInterface
 
 
 class ApiRunner:
     """Run the Speculos API server, with a notification when it stops"""
     def __init__(self, api_port: int) -> None:
+        self._app : Optional[Flask] = None
         # self.s is used by Screen.add_notifier. Closing self._notify_exit
         # signals it that the API is no longer running.
+        self.s : socket.socket
+        self._notify_exit : socket.socket
         self.s, self._notify_exit = socket.socketpair()
-        self.api_port = api_port
+        self.api_port : int = api_port
 
     def can_read(self, s: int, screen) -> None:
         assert s == self.s.fileno()
@@ -67,217 +36,73 @@ class ApiRunner:
     def _run(self) -> None:
         try:
             # threaded must be set to allow serving requests along events streaming
-            app.run(host="0.0.0.0", port=self.api_port, threaded=True, use_reloader=False)
+            self._app.run(host="0.0.0.0", port=self.api_port, threaded=True, use_reloader=False)
         except Exception as exc:
-            app.logger.error("an exception occurred in the Flask API server: %s", exc)
-            raise
+            self._app.logger.error("An exception occurred in the Flask API server: %s", exc)
+            raise exc
         finally:
             self._notify_exit.close()
 
-    def start_server_thread(self, screen_, seph_) -> None:
-        global screen, seph
-        screen, seph = screen_, seph_
-        seph.apdu_callbacks.append(apdu.seph_apdu_callback)
+    def start_server_thread(self, screen_, seph_: SeProxyHal) -> None:
+        wrapper = ApiWrapper(screen_, seph_)
+        self._app = wrapper.app
         api_thread = threading.Thread(target=self._run, name="API-server", daemon=True)
         api_thread.start()
 
 
-def load_json_schema(filename):
-    path = os.path.join("resources", filename)
-    with pkg_resources.resource_stream(__name__, path) as fp:
-        schema = json.load(fp)
-    return schema
+class ApiWrapper:
+    def __init__(self, screen, seph: SeProxyHal):
+        self._screen = screen
+        self._seph = seph
+        self._set_app()
 
+        self._api = Api(self.app)
+        self._api.add_resource(APDU, "/apdu",
+                               resource_class_kwargs=self._seph_kwargs)
+        self._api.add_resource(Automation, "/automation",
+                               resource_class_kwargs=self._seph_kwargs)
+        self._api.add_resource(Button, "/button/left", "/button/right", "/button/both",
+                               resource_class_kwargs=self._seph_kwargs)
+        self._api.add_resource(Events, "/events",
+                               resource_class_kwargs=self._app_kwargs)
+        self._api.add_resource(Finger, "/finger",
+                               resource_class_kwargs=self._seph_kwargs)
+        self._api.add_resource(Screenshot, "/screenshot",
+                               resource_class_kwargs=self._screen_kwargs)
+        self._api.add_resource(Swagger, "/swagger/",
+                               resource_class_kwargs=self._app_kwargs)
+        self._api.add_resource(WebInterface, "/",
+                               resource_class_kwargs=self._app_kwargs)
 
-class Automation(Resource):
-    def post(self):
-        document = request.get_data()
+    def _set_app(self):
+        static_folder = pkg_resources.resource_filename(__name__, "/static")
+        self._app = Flask(__name__, static_url_path="", static_folder=static_folder)
+        self._app.env = "development"
 
-        try:
-            document = document.decode("ascii")
-        except UnicodeDecodeError:
-            return "invalid encoding", 400
+    @property
+    def _screen_kwargs(self):
+        return {'screen': self.screen}
 
-        if document.startswith("file:"):
-            return "invalid document", 400
+    @property
+    def _app_kwargs(self) -> Dict[str, Flask]:
+        return {'app': self.app}
 
-        try:
-            rules = mcu_automation.Automation(document)
-        except json.decoder.JSONDecodeError:
-            return "invalid document", 400
-        except jsonschema.exceptions.ValidationError:
-            return "invalid document", 400
+    @property
+    def _seph_kwargs(self) -> Dict[str, SeProxyHal]:
+        return {'seph': self.seph}
 
-        seph.automation = rules
+    @property
+    def app(self) -> Flask:
+        return self._app
 
-        return {}, 200
+    @property
+    def api(self) -> Api:
+        return self._api
 
+    @property
+    def screen(self):
+        return self._screen
 
-class Button(Resource):
-    schema = load_json_schema("button.schema")
-
-    def post(self):
-        args = request.get_json(force=True)
-        try:
-            jsonschema.validate(instance=args, schema=self.schema)
-        except jsonschema.exceptions.ValidationError as e:
-            return {"error": f"{e}"}, 400
-
-        button = request.base_url.split("/")[-1]
-        buttons = {"left": [1], "right": [2], "both": [1, 2]}
-        action = args["action"]
-        actions = {"press": [True], "release": [False], "press-and-release": [True, False]}
-        delay = args.get("delay", 0.1)
-
-        for a in actions[action]:
-            for b in buttons[button]:
-                seph.handle_button(b, a)
-            if action == "press-and-release":
-                time.sleep(delay)
-
-        return {}, 200
-
-
-class EventClient:
-    def __init__(self):
-        self.events = []
-
-    def generate(self):
-        try:
-            # force headers to be sent
-            yield b""
-
-            while True:
-                with events.condition:
-                    events.condition.wait(1)
-
-                while self.events:
-                    event = self.events.pop(0)
-                    data = json.dumps(event)
-                    # Format the event as specified in the specification:
-                    # https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
-                    yield f"data: {data}\n\n".encode()
-        finally:
-            events.remove_client(self)
-
-    def send_screen_event(self, event):
-        self.events.append(event)
-
-
-class Events(Resource):
-    def __init__(self):
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument("stream", type=inputs.boolean, default=False)
-        super(Events, self).__init__()
-
-    def get(self):
-        args = self.parser.parse_args()
-        if args.stream:
-            client = EventClient()
-            events.add_client(client)
-            return Response(stream_with_context(client.generate()), content_type="text/event-stream")
-        else:
-            return {"events": events.events}, 200
-
-    def delete(self):
-        events.events.clear()
-        return {}, 200
-
-
-class Finger(Resource):
-    schema = load_json_schema("finger.schema")
-
-    def post(self):
-        args = request.get_json(force=True)
-        try:
-            jsonschema.validate(instance=args, schema=self.schema)
-        except jsonschema.exceptions.ValidationError as e:
-            return {"error": f"{e}"}, 400
-
-        action = args["action"]
-        actions = {"press": [True], "release": [False], "press-and-release": [True, False]}
-        delay = args.get("delay", 0.1)
-
-        for a in actions[action]:
-            seph.handle_finger(args["x"], args["y"], a)
-            if action == "press-and-release":
-                time.sleep(delay)
-
-        return {}, 200
-
-
-class APDUBridge:
-    def __init__(self):
-        # We want to be notified when APDU response is transmitted from the SE
-        self.endpoint_lock = threading.Lock()
-        self.response_condition = threading.Condition()
-
-    def exchange(self, data: bytes) -> Generator[bytes, None, None]:
-        # force headers to be sent
-        yield b""
-
-        with self.endpoint_lock:  # Lock for a command/response for one client
-            with self.response_condition:
-                self.response = None
-            seph.to_app(data)
-            with self.response_condition:
-                while self.response is None:
-                    self.response_condition.wait()
-            yield json.dumps({"data": self.response.hex()}).encode()
-
-    def seph_apdu_callback(self, data: bytes):
-        """
-        Called by seph when data is transmitted by the SE. That data should
-        be the response to a prior APDU request
-        """
-        with self.response_condition:
-            self.response = data
-            self.response_condition.notify()
-
-
-apdu = APDUBridge()
-
-
-class APDU(Resource):
-    schema = load_json_schema("apdu.schema")
-
-    def post(self):
-        args = request.get_json(force=True)
-        try:
-            jsonschema.validate(instance=args, schema=self.schema)
-        except jsonschema.exceptions.ValidationError as e:
-            return {"error": f"{e}"}, 400
-
-        data = bytes.fromhex(args.get("data"))
-        return Response(stream_with_context(apdu.exchange(data)), content_type="application/json")
-
-
-class Screenshot(Resource):
-    def get(self):
-        screen_size, data = screen.m.take_screenshot()
-        image = Image.frombytes("RGB", screen_size, data)
-        iobytes = io.BytesIO()
-        image.save(iobytes, format="PNG")
-        response = Response(iobytes.getvalue(), mimetype="image/png")
-        response.headers.add("Cache-control", "no-cache,no-store")
-        return response
-
-
-class Swagger(Resource):
-    def get(self):
-        return app.send_static_file("swagger/index.html")
-
-
-class WebInterface(Resource):
-    def get(self):
-        return app.send_static_file("index.html")
-
-
-api.add_resource(APDU, "/apdu")
-api.add_resource(Automation, "/automation")
-api.add_resource(Button, "/button/left", "/button/right", "/button/both")
-api.add_resource(Events, "/events")
-api.add_resource(Finger, "/finger")
-api.add_resource(Screenshot, "/screenshot")
-api.add_resource(Swagger, "/swagger/")
-api.add_resource(WebInterface, "/")
+    @property
+    def seph(self) -> SeProxyHal:
+        return self._seph

--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -68,7 +68,7 @@ class ApiWrapper:
                                resource_class_kwargs=self._seph_kwargs)
         self._api.add_resource(Events, "/events",
                                resource_class_kwargs={**self._app_kwargs,
-                                                      'automation_server': automation_server})
+                                                      "automation_server": automation_server})
         self._api.add_resource(Finger, "/finger",
                                resource_class_kwargs=self._seph_kwargs)
         self._api.add_resource(Screenshot, "/screenshot",
@@ -85,15 +85,15 @@ class ApiWrapper:
 
     @property
     def _screen_kwargs(self):
-        return {'screen': self.screen}
+        return {"screen": self.screen}
 
     @property
     def _app_kwargs(self) -> Dict[str, Flask]:
-        return {'app': self.app}
+        return {"app": self.app}
 
     @property
     def _seph_kwargs(self) -> Dict[str, SeProxyHal]:
-        return {'seph': self.seph}
+        return {"seph": self.seph}
 
     @property
     def app(self) -> Flask:

--- a/speculos/api/automation.py
+++ b/speculos/api/automation.py
@@ -1,0 +1,30 @@
+import json
+import jsonschema
+from flask import request
+
+from ..mcu import automation as mcu_automation
+from .restful import SephResource
+
+
+class Automation(SephResource):
+    def post(self):
+        document = request.get_data()
+
+        try:
+            document = document.decode("ascii")
+        except UnicodeDecodeError:
+            return "invalid encoding", 400
+
+        if document.startswith("file:"):
+            return "invalid document", 400
+
+        try:
+            rules = mcu_automation.Automation(document)
+        except json.decoder.JSONDecodeError:
+            return "invalid document", 400
+        except jsonschema.exceptions.ValidationError:
+            return "invalid document", 400
+
+        self.seph.automation = rules
+
+        return {}, 200

--- a/speculos/api/button.py
+++ b/speculos/api/button.py
@@ -1,0 +1,31 @@
+import time
+import jsonschema
+from flask import request
+
+from .helpers import load_json_schema
+from .restful import SephResource
+
+
+class Button(SephResource):
+    schema = load_json_schema("button.schema")
+
+    def post(self):
+        args = request.get_json(force=True)
+        try:
+            jsonschema.validate(instance=args, schema=self.schema)
+        except jsonschema.exceptions.ValidationError as e:
+            return {"error": f"{e}"}, 400
+
+        button = request.base_url.split("/")[-1]
+        buttons = {"left": [1], "right": [2], "both": [1, 2]}
+        action = args["action"]
+        actions = {"press": [True], "release": [False], "press-and-release": [True, False]}
+        delay = args.get("delay", 0.1)
+
+        for a in actions[action]:
+            for b in buttons[button]:
+                self.seph.handle_button(b, a)
+            if action == "press-and-release":
+                time.sleep(delay)
+
+        return {}, 200

--- a/speculos/api/events.py
+++ b/speculos/api/events.py
@@ -15,7 +15,7 @@ class EventsBroadcaster:
         self.clients = []
         self.events = []
         self.condition = threading.Condition()
-        self.logger = logging.getLogger('events')
+        self.logger = logging.getLogger("events")
 
     def add_client(self, client):
         self.logger.debug("events: new client")
@@ -64,7 +64,7 @@ class EventClient:
 class Events(AppResource):
     def __init__(self, *args, automation_server: Optional[EventsBroadcaster] = None, **kwargs):
         if automation_server is None:
-            raise RuntimeError('Argument \'automation_server\' must not be None')
+            raise RuntimeError("Argument 'automation_server' must not be None")
         self._broadcaster = automation_server
         self.parser = reqparse.RequestParser()
         self.parser.add_argument("stream", type=inputs.boolean, default=False)

--- a/speculos/api/events.py
+++ b/speculos/api/events.py
@@ -34,7 +34,6 @@ class EventsBroadcaster:
             self.condition.notify_all()
 
 
-
 class EventClient:
     def __init__(self, broadcaster: EventsBroadcaster):
         self.events = []

--- a/speculos/api/events.py
+++ b/speculos/api/events.py
@@ -1,0 +1,82 @@
+import json
+import logging
+import threading
+from flask import stream_with_context, Response
+from flask_restful import inputs, reqparse
+
+from .restful import AppResource
+
+
+class EventsBroadcaster:
+    """This used to be the 'Automation Server'."""
+
+    def __init__(self):
+        self.clients = []
+        self.events = []
+        self.condition = threading.Condition()
+        self.logger = logging.getLogger('events')
+
+    def add_client(self, client):
+        self.logger.debug("events: new client")
+        self.clients.append(client)
+
+    def remove_client(self, client):
+        self.logger.debug("events: client exited")
+        self.clients.remove(client)
+
+    def broadcast(self, event):
+        self.logger.debug(f"events: broadcasting {event} to ({len(self.clients)}) client(s)")
+        self.events.append(event)
+        for client in self.clients:
+            client.send_screen_event(event)
+        with self.condition:
+            self.condition.notify_all()
+
+
+events = EventsBroadcaster()
+
+
+class EventClient:
+    def __init__(self):
+        self.events = []
+
+    def generate(self):
+        try:
+            # force headers to be sent
+            yield b""
+
+            while True:
+                with events.condition:
+                    events.condition.wait(1)
+
+                while self.events:
+                    event = self.events.pop(0)
+                    data = json.dumps(event)
+                    # Format the event as specified in the specification:
+                    # https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
+                    yield f"data: {data}\n\n".encode()
+        finally:
+            events.remove_client(self)
+
+    def send_screen_event(self, event):
+        self.events.append(event)
+
+
+class Events(AppResource):
+    def __init__(self, *args, **kwargs):
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument("stream", type=inputs.boolean, default=False)
+        super().__init__(*args, **kwargs)
+
+    def get(self):
+        args = self.parser.parse_args()
+        if args.stream:
+            client = EventClient()
+            events.add_client(client)
+            return Response(stream_with_context(client.generate()), content_type="text/event-stream")
+        else:
+            return {"events": events.events}, 200
+
+    def delete(self):
+        events.events.clear()
+        return {}, 200

--- a/speculos/api/finger.py
+++ b/speculos/api/finger.py
@@ -1,0 +1,28 @@
+import time
+import jsonschema
+from flask import request
+
+from .helpers import load_json_schema
+from .restful import SephResource
+
+
+class Finger(SephResource):
+    schema = load_json_schema("finger.schema")
+
+    def post(self):
+        args = request.get_json(force=True)
+        try:
+            jsonschema.validate(instance=args, schema=self.schema)
+        except jsonschema.exceptions.ValidationError as e:
+            return {"error": f"{e}"}, 400
+
+        action = args["action"]
+        actions = {"press": [True], "release": [False], "press-and-release": [True, False]}
+        delay = args.get("delay", 0.1)
+
+        for a in actions[action]:
+            self.seph.handle_finger(args["x"], args["y"], a)
+            if action == "press-and-release":
+                time.sleep(delay)
+
+        return {}, 200

--- a/speculos/api/helpers.py
+++ b/speculos/api/helpers.py
@@ -1,0 +1,10 @@
+import json
+import os.path
+import pkg_resources
+
+
+def load_json_schema(filename):
+    path = os.path.join("resources", filename)
+    with pkg_resources.resource_stream(__name__, path) as fp:
+        schema = json.load(fp)
+    return schema

--- a/speculos/api/restful.py
+++ b/speculos/api/restful.py
@@ -8,7 +8,7 @@ from ..mcu.seproxyhal import SeProxyHal
 class SephResource(Resource):
     def __init__(self, *args, seph: Optional[SeProxyHal] = None, **kwargs):
         if seph is None:
-            raise RuntimeError('Argument \'seph\' must not be None')
+            raise RuntimeError("Argument 'seph' must not be None")
         super().__init__(*args, **kwargs)
         self._seph = seph
 
@@ -20,7 +20,7 @@ class SephResource(Resource):
 class AppResource(Resource):
     def __init__(self, *args, app: Optional[Flask] = None, **kwargs):
         if app is None:
-            raise RuntimeError('Argument \'app\' must not be None')
+            raise RuntimeError("Argument 'app' must not be None")
         super().__init__(*args, **kwargs)
         self._app = app
 
@@ -32,7 +32,7 @@ class AppResource(Resource):
 class ScreenResource(Resource):
     def __init__(self, *args, screen=None, **kwargs):
         if screen is None:
-            raise RuntimeError('Argument \'screen\' must not be None')
+            raise RuntimeError("Argument 'screen' must not be None")
         super().__init__(*args, **kwargs)
         self._screen = screen
 

--- a/speculos/api/restful.py
+++ b/speculos/api/restful.py
@@ -1,0 +1,38 @@
+from flask import Flask
+from typing import Optional
+from flask_restful import Resource
+
+from ..mcu.seproxyhal import SeProxyHal
+
+
+class SephResource(Resource):
+    def __init__(self, *args, seph : Optional[SeProxyHal] = None, **kwargs):
+        if seph is None:
+            raise RuntimeError('Argument \'seph\' must not be None')
+        super().__init__(*args, **kwargs)
+        self._seph = seph
+    @property
+    def seph(self):
+        return self._seph
+
+
+class AppResource(Resource):
+    def __init__(self, *args, app : Optional[Flask] = None, **kwargs):
+        if app is None:
+            raise RuntimeError('Argument \'app\' must not be None')
+        super().__init__(*args, **kwargs)
+        self._app = app
+    @property
+    def app(self):
+        return self._app
+
+
+class ScreenResource(Resource):
+    def __init__(self, *args, screen=None, **kwargs):
+        if screen is None:
+            raise RuntimeError('Argument \'screen\' must not be None')
+        super().__init__(*args, **kwargs)
+        self._screen = screen
+    @property
+    def screen(self):
+        return self._screen

--- a/speculos/api/restful.py
+++ b/speculos/api/restful.py
@@ -6,22 +6,24 @@ from ..mcu.seproxyhal import SeProxyHal
 
 
 class SephResource(Resource):
-    def __init__(self, *args, seph : Optional[SeProxyHal] = None, **kwargs):
+    def __init__(self, *args, seph: Optional[SeProxyHal] = None, **kwargs):
         if seph is None:
             raise RuntimeError('Argument \'seph\' must not be None')
         super().__init__(*args, **kwargs)
         self._seph = seph
+
     @property
     def seph(self):
         return self._seph
 
 
 class AppResource(Resource):
-    def __init__(self, *args, app : Optional[Flask] = None, **kwargs):
+    def __init__(self, *args, app: Optional[Flask] = None, **kwargs):
         if app is None:
             raise RuntimeError('Argument \'app\' must not be None')
         super().__init__(*args, **kwargs)
         self._app = app
+
     @property
     def app(self):
         return self._app
@@ -33,6 +35,7 @@ class ScreenResource(Resource):
             raise RuntimeError('Argument \'screen\' must not be None')
         super().__init__(*args, **kwargs)
         self._screen = screen
+
     @property
     def screen(self):
         return self._screen

--- a/speculos/api/screenshot.py
+++ b/speculos/api/screenshot.py
@@ -1,0 +1,16 @@
+import io
+from PIL import Image
+from flask import Response
+
+from .restful import ScreenResource
+
+
+class Screenshot(ScreenResource):
+    def get(self):
+        screen_size, data = self.screen.m.take_screenshot()
+        image = Image.frombytes("RGB", screen_size, data)
+        iobytes = io.BytesIO()
+        image.save(iobytes, format="PNG")
+        response = Response(iobytes.getvalue(), mimetype="image/png")
+        response.headers.add("Cache-control", "no-cache,no-store")
+        return response

--- a/speculos/api/swagger.py
+++ b/speculos/api/swagger.py
@@ -1,0 +1,6 @@
+from .restful import AppResource
+
+
+class Swagger(AppResource):
+    def get(self):
+        return self.app.send_static_file("swagger/index.html")

--- a/speculos/api/web_interface.py
+++ b/speculos/api/web_interface.py
@@ -1,0 +1,6 @@
+from .restful import AppResource
+
+
+class WebInterface(AppResource):
+    def get(self):
+        return self.app.send_static_file("index.html")

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -19,7 +19,7 @@ import threading
 
 import pkg_resources
 
-from .api import ApiRunner, events
+from .api import ApiRunner, EventsBroadcaster
 from .mcu import apdu as apdu_server
 from .mcu import automation
 from .mcu import display
@@ -277,7 +277,7 @@ def main(prog=None):
         automation_thread.start()
 
     if api_enabled:
-        automation_server = events
+        automation_server = EventsBroadcaster()
 
     s1, s2 = socket.socketpair()
 
@@ -325,7 +325,7 @@ def main(prog=None):
     screen = Screen(display_args, server_args)
 
     if api_enabled:
-        apirun.start_server_thread(screen, seph)
+        apirun.start_server_thread(screen, seph, automation_server)
 
     screen.run()
 

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -19,7 +19,7 @@ import threading
 
 import pkg_resources
 
-from .api import api
+from .api import ApiRunner, events
 from .mcu import apdu as apdu_server
 from .mcu import automation
 from .mcu import display
@@ -28,6 +28,7 @@ from .mcu.automation_server import AutomationClient, AutomationServer
 from .mcu.button_tcp import FakeButton
 from .mcu.finger_tcp import FakeFinger
 from .mcu.vnc import VNC
+
 
 DEFAULT_SEED = ('glory promote mansion idle axis finger extra february uncover one trip resource lawn turtle enact '
                 'monster seven myth punch hobby comfort wild raise skin')
@@ -269,14 +270,14 @@ def main(prog=None):
     if args.automation_port:
         logger.warn("--automation-port is deprecated, please use the REST API instead")
         if api_enabled:
-            logger.warn("--automation-port is incompatible with the the API server, disabling it")
+            logger.warn("--automation-port is incompatible with the the API server, disabling the latter")
             api_enabled = False
         automation_server = AutomationServer(("0.0.0.0", args.automation_port), AutomationClient)
         automation_thread = threading.Thread(target=automation_server.serve_forever, daemon=True)
         automation_thread.start()
 
     if api_enabled:
-        automation_server = api.events
+        automation_server = events
 
     s1, s2 = socket.socketpair()
 
@@ -317,7 +318,7 @@ def main(prog=None):
 
     apirun = None
     if api_enabled:
-        apirun = api.ApiRunner(args.api_port)
+        apirun = ApiRunner(args.api_port)
 
     display_args = display.DisplayArgs(args.color, args.model, args.ontop, rendering, args.keymap, zoom, x, y)
     server_args = display.ServerArgs(apdu, apirun, button, finger, seph, vnc)


### PR DESCRIPTION
`main.py` & `api.py` code seems to rely on globals, either Flask-related (`app`, `api`) or not (`seph`, `screen`, `events`).

This PR tries to push these variables in narrower context to enforce a straighter execution flow.
This should be isofunctional, but may have side-effects given my budding understanding of speculos. I'm eager for feedbacks on this.

The base trick is the addition in `speculos.api.restful` of `flask_restful.Resource` subclasses expecting arguments (`app`, `seph` or `screen`). `api`, `app` and the `*Resources` are then initialized in the new `ApiWrapper` class, itself used by the existing `ApiRunner` class to initialize the `app` and `run` it.

* `app` and `api` stay nested in `ApiRunner` and/or `ApiWrapper`.
* `events` is now instanciated in `main.py` if needed (if `api_enabled`) and given to the needing resources as an argument through * `ApiRunner / ApiWrapper`
* `screen` and `seph` are still instantiated in the same place (`main.py`) but distributed by arguments through `ApiRunner / ApiWrapper` rather than stored in `speculos.api.api` globals.


I lied about isofunctionality: `EventsBroadcaster` was previously using the `app.logger` for its logs. Given `app` is now hidden in `ApiWrapper`, and `EventsBroadcaster` is not directly connected to it, I took the liberty of giving it its own logger, rather than using a setter or whatnot to feed it the `app.logger`.  