### PR TITLE
client: fix error when closing stream

### DIFF
--- a/speculos/client.py
+++ b/speculos/client.py
@@ -73,7 +73,8 @@ class Api:
         check_status_code(self.stream, "/events")
 
     def close_stream(self) -> None:
-        self.stream.close()
+        if self.stream:
+            self.stream.close()
         self.stream = None
 
     def get_next_event(self) -> dict:

--- a/tests/unit/test_client_Api.py
+++ b/tests/unit/test_client_Api.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from speculos.client import Api
+
+
+class TestApi(TestCase):
+
+    def setUp(self):
+        self.api_url = 'some random url'
+        self.api = Api(self.api_url)
+
+    def test_close_stream_None_should_not_raise(self):
+        self.assertIsNone(self.api.stream)
+        self.api.close_stream()

--- a/tests/unit/test_client_SpeculosClient.py
+++ b/tests/unit/test_client_SpeculosClient.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from speculos.client import SpeculosClient
+
+
+class TestSpeculosClient(TestCase):
+
+    def setUp(self):
+        self.app = 'app'
+        self.args = ['some', 'arguments']
+        self.client = SpeculosClient(self.app, self.args)
+
+    def test_stop_successive_should_not_raise(self):
+        self.assertIsNone(self.client.stream)
+        self.client.stop()
+
+    def test_stop_successive_should_not_raise2(self):
+        self.client.start = lambda: None
+        with self.client:
+            self.client.stop()


### PR DESCRIPTION
```
  Traceback (most recent call last):
    File "./demo.py", line 125, in <module>
      client.stop()
    File "/speculos/speculos/client.py", line 224, in __exit__
      self.stop()
    File "/speculos/speculos/client.py", line 213, in stop
      self.close_stream()
    File "/speculos/speculos/client.py", line 76, in close_stream
      self.stream.close()
  AttributeError: 'NoneType' object has no attribute 'close'
```