### PR TITLE
Default to SDK 2.1.0 for LNS

### DIFF
--- a/speculos/main.py
+++ b/speculos/main.py
@@ -253,7 +253,7 @@ def main(prog=None):
 
     if args.sdk is None:
         default_sdk = {
-            "nanos": "2.0",
+            "nanos": "2.1",
             "nanox": "2.0",
             "blue": "blue-2.2.5",
         }


### PR DESCRIPTION
Modified the default SDK for Nano S to be version 2.1.0 instead of 2.0.0
cxlib for it already existing since #250 