### PR TITLE
Harden compilation flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_compile_options(-Wextra -Wcast-qual -Wshadow -Werror)
+
 add_library(emu
         bolos/cx_aes.c
         bolos/cx_aes_sdk2.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_compile_options(-Wextra -Wcast-qual -Wshadow -Werror)
+add_compile_options(-Wextra -Wcast-qual -Wshadow -Werror
+        -Wformat=2 -Wformat-overflow=2 -Wformat-truncation=2 -Wformat-security -Wformat-signedness
+)
 
 add_library(emu
         bolos/cx_aes.c

--- a/src/bolos/cx_aes_sdk2.c
+++ b/src/bolos/cx_aes_sdk2.c
@@ -16,7 +16,7 @@ static uint32_t local_aes_mode;
 //-----------------------------------------------------------------------------
 cx_err_t sys_cx_aes_set_key_hw(const cx_aes_key_t *key, uint32_t mode)
 {
-  memcpy((void *)&local_aes_key, (void *)key, sizeof(local_aes_key));
+  memcpy(&local_aes_key, key, sizeof(local_aes_key));
   local_aes_mode = mode;
   local_aes_ready = true;
 

--- a/src/bolos/cx_ec.c
+++ b/src/bolos/cx_ec.c
@@ -75,15 +75,15 @@ static cx_curve_weierstrass_t const C_cx_secp256k1 = {
   CX_CURVE_SECP256K1,
   256,
   32,
-  (unsigned char *)C_cx_secp256k1_p,
-  (unsigned char *)C_cx_secp256k1_Hp,
-  (unsigned char *)C_cx_secp256k1_Gx,
-  (unsigned char *)C_cx_secp256k1_Gy,
-  (unsigned char *)C_cx_secp256k1_n,
-  (unsigned char *)C_cx_secp256k1_Hn,
+  C_cx_secp256k1_p,
+  C_cx_secp256k1_Hp,
+  C_cx_secp256k1_Gx,
+  C_cx_secp256k1_Gy,
+  C_cx_secp256k1_n,
+  C_cx_secp256k1_Hn,
   C_cx_secp256k1_h,
-  (unsigned char *)C_cx_secp256k1_a,
-  (unsigned char *)C_cx_secp256k1_b,
+  C_cx_secp256k1_a,
+  C_cx_secp256k1_b,
 };
 
 static unsigned char const C_cx_secp256r1_a[] = {
@@ -137,15 +137,15 @@ static cx_curve_weierstrass_t const C_cx_secp256r1 = {
   CX_CURVE_SECP256R1,
   256,
   32,
-  (unsigned char *)C_cx_secp256r1_p,
-  (unsigned char *)C_cx_secp256r1_Hp,
-  (unsigned char *)C_cx_secp256r1_Gx,
-  (unsigned char *)C_cx_secp256r1_Gy,
-  (unsigned char *)C_cx_secp256r1_n,
-  (unsigned char *)C_cx_secp256r1_Hn,
+  C_cx_secp256r1_p,
+  C_cx_secp256r1_Hp,
+  C_cx_secp256r1_Gx,
+  C_cx_secp256r1_Gy,
+  C_cx_secp256r1_n,
+  C_cx_secp256r1_Hn,
   C_cx_secp256r1_h,
-  (unsigned char *)C_cx_secp256r1_a,
-  (unsigned char *)C_cx_secp256r1_b,
+  C_cx_secp256r1_a,
+  C_cx_secp256r1_b,
 };
 
 static uint8_t const C_cx_secp384r1_a[] = {
@@ -211,15 +211,15 @@ static cx_curve_weierstrass_t const C_cx_secp384r1 = {
   CX_CURVE_SECP384R1,
   384,
   48,
-  (unsigned char *)C_cx_secp384r1_p,
-  (unsigned char *)C_cx_secp384r1_Hp,
-  (unsigned char *)C_cx_secp384r1_Gx,
-  (unsigned char *)C_cx_secp384r1_Gy,
-  (unsigned char *)C_cx_secp384r1_n,
-  (unsigned char *)C_cx_secp384r1_Hn,
+  C_cx_secp384r1_p,
+  C_cx_secp384r1_Hp,
+  C_cx_secp384r1_Gx,
+  C_cx_secp384r1_Gy,
+  C_cx_secp384r1_n,
+  C_cx_secp384r1_Hn,
   C_cx_secp384r1_h,
-  (unsigned char *)C_cx_secp384r1_a,
-  (unsigned char *)C_cx_secp384r1_b,
+  C_cx_secp384r1_a,
+  C_cx_secp384r1_b,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -279,15 +279,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP256r1 = {
   .bit_size = 256,
   .length = 32,
 
-  .a = (uint8_t *)C_cx_BrainpoolP256r1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP256r1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP256r1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP256r1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP256r1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP256r1_n,
+  .a = C_cx_BrainpoolP256r1_a,
+  .b = C_cx_BrainpoolP256r1_b,
+  .p = C_cx_BrainpoolP256r1_p,
+  .Gx = C_cx_BrainpoolP256r1_Gx,
+  .Gy = C_cx_BrainpoolP256r1_Gy,
+  .n = C_cx_BrainpoolP256r1_n,
   .h = C_cx_BrainpoolP256r1_h,
-  .Hn = (uint8_t *)C_cx_BrainpoolP256r1_Hn,
-  .Hp = (uint8_t *)C_cx_BrainpoolP256r1_Hp,
+  .Hn = C_cx_BrainpoolP256r1_Hn,
+  .Hp = C_cx_BrainpoolP256r1_Hp,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -347,15 +347,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP256t1 = {
   .bit_size = 256,
   .length = 32,
 
-  .a = (uint8_t *)C_cx_BrainpoolP256t1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP256t1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP256t1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP256t1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP256t1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP256t1_n,
+  .a = C_cx_BrainpoolP256t1_a,
+  .b = C_cx_BrainpoolP256t1_b,
+  .p = C_cx_BrainpoolP256t1_p,
+  .Gx = C_cx_BrainpoolP256t1_Gx,
+  .Gy = C_cx_BrainpoolP256t1_Gy,
+  .n = C_cx_BrainpoolP256t1_n,
   .h = C_cx_BrainpoolP256t1_h,
-  .Hn = (uint8_t *)C_cx_BrainpoolP256t1_Hn,
-  .Hp = (uint8_t *)C_cx_BrainpoolP256t1_Hp,
+  .Hn = C_cx_BrainpoolP256t1_Hn,
+  .Hp = C_cx_BrainpoolP256t1_Hp,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -429,15 +429,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP320r1 = {
   .bit_size = 320,
   .length = 40,
 
-  .a = (uint8_t *)C_cx_BrainpoolP320r1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP320r1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP320r1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP320r1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP320r1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP320r1_n,
+  .a = C_cx_BrainpoolP320r1_a,
+  .b = C_cx_BrainpoolP320r1_b,
+  .p = C_cx_BrainpoolP320r1_p,
+  .Gx = C_cx_BrainpoolP320r1_Gx,
+  .Gy = C_cx_BrainpoolP320r1_Gy,
+  .n = C_cx_BrainpoolP320r1_n,
   .h = C_cx_BrainpoolP320r1_h,
-  .Hp = (uint8_t *)C_cx_BrainpoolP320r1_Hp,
-  .Hn = (uint8_t *)C_cx_BrainpoolP320r1_Hn,
+  .Hp = C_cx_BrainpoolP320r1_Hp,
+  .Hn = C_cx_BrainpoolP320r1_Hn,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -512,15 +512,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP320t1 = {
   .bit_size = 320,
   .length = 40,
 
-  .a = (uint8_t *)C_cx_BrainpoolP320t1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP320t1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP320t1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP320t1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP320t1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP320t1_n,
+  .a = C_cx_BrainpoolP320t1_a,
+  .b = C_cx_BrainpoolP320t1_b,
+  .p = C_cx_BrainpoolP320t1_p,
+  .Gx = C_cx_BrainpoolP320t1_Gx,
+  .Gy = C_cx_BrainpoolP320t1_Gy,
+  .n = C_cx_BrainpoolP320t1_n,
   .h = C_cx_BrainpoolP320t1_h,
-  .Hp = (uint8_t *)C_cx_BrainpoolP320t1_Hp,
-  .Hn = (uint8_t *)C_cx_BrainpoolP320t1_Hn,
+  .Hp = C_cx_BrainpoolP320t1_Hp,
+  .Hn = C_cx_BrainpoolP320t1_Hn,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -594,15 +594,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP384r1 = {
   .bit_size = 384,
   .length = 48,
 
-  .a = (uint8_t *)C_cx_BrainpoolP384r1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP384r1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP384r1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP384r1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP384r1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP384r1_n,
+  .a = C_cx_BrainpoolP384r1_a,
+  .b = C_cx_BrainpoolP384r1_b,
+  .p = C_cx_BrainpoolP384r1_p,
+  .Gx = C_cx_BrainpoolP384r1_Gx,
+  .Gy = C_cx_BrainpoolP384r1_Gy,
+  .n = C_cx_BrainpoolP384r1_n,
   .h = C_cx_BrainpoolP384r1_h,
-  .Hp = (uint8_t *)C_cx_BrainpoolP384r1_Hp,
-  .Hn = (uint8_t *)C_cx_BrainpoolP384r1_Hn,
+  .Hp = C_cx_BrainpoolP384r1_Hp,
+  .Hn = C_cx_BrainpoolP384r1_Hn,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -676,15 +676,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP384t1 = {
   .bit_size = 384,
   .length = 48,
 
-  .a = (uint8_t *)C_cx_BrainpoolP384t1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP384t1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP384t1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP384t1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP384t1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP384t1_n,
+  .a = C_cx_BrainpoolP384t1_a,
+  .b = C_cx_BrainpoolP384t1_b,
+  .p = C_cx_BrainpoolP384t1_p,
+  .Gx = C_cx_BrainpoolP384t1_Gx,
+  .Gy = C_cx_BrainpoolP384t1_Gy,
+  .n = C_cx_BrainpoolP384t1_n,
   .h = C_cx_BrainpoolP384t1_h,
-  .Hp = (uint8_t *)C_cx_BrainpoolP384t1_Hp,
-  .Hn = (uint8_t *)C_cx_BrainpoolP384t1_Hn,
+  .Hp = C_cx_BrainpoolP384t1_Hp,
+  .Hn = C_cx_BrainpoolP384t1_Hn,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -766,15 +766,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP512r1 = {
   .bit_size = 512,
   .length = 64,
 
-  .a = (uint8_t *)C_cx_BrainpoolP512r1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP512r1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP512r1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP512r1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP512r1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP512r1_n,
+  .a = C_cx_BrainpoolP512r1_a,
+  .b = C_cx_BrainpoolP512r1_b,
+  .p = C_cx_BrainpoolP512r1_p,
+  .Gx = C_cx_BrainpoolP512r1_Gx,
+  .Gy = C_cx_BrainpoolP512r1_Gy,
+  .n = C_cx_BrainpoolP512r1_n,
   .h = C_cx_BrainpoolP512r1_h,
-  .Hp = (uint8_t *)C_cx_BrainpoolP512r1_Hp,
-  .Hn = (uint8_t *)C_cx_BrainpoolP512r1_Hn,
+  .Hp = C_cx_BrainpoolP512r1_Hp,
+  .Hn = C_cx_BrainpoolP512r1_Hn,
 };
 
 /* ------------------------------------------------------------------------ */
@@ -856,15 +856,15 @@ static cx_curve_weierstrass_t const C_cx_BrainpoolP512t1 = {
   .bit_size = 512,
   .length = 64,
 
-  .a = (uint8_t *)C_cx_BrainpoolP512t1_a,
-  .b = (uint8_t *)C_cx_BrainpoolP512t1_b,
-  .p = (uint8_t *)C_cx_BrainpoolP512t1_p,
-  .Gx = (uint8_t *)C_cx_BrainpoolP512t1_Gx,
-  .Gy = (uint8_t *)C_cx_BrainpoolP512t1_Gy,
-  .n = (uint8_t *)C_cx_BrainpoolP512t1_n,
+  .a = C_cx_BrainpoolP512t1_a,
+  .b = C_cx_BrainpoolP512t1_b,
+  .p = C_cx_BrainpoolP512t1_p,
+  .Gx = C_cx_BrainpoolP512t1_Gx,
+  .Gy = C_cx_BrainpoolP512t1_Gy,
+  .n = C_cx_BrainpoolP512t1_n,
   .h = C_cx_BrainpoolP512t1_h,
-  .Hn = (uint8_t *)C_cx_BrainpoolP512t1_Hn,
-  .Hp = (uint8_t *)C_cx_BrainpoolP512t1_Hp,
+  .Hn = C_cx_BrainpoolP512t1_Hn,
+  .Hp = C_cx_BrainpoolP512t1_Hp,
 
 };
 
@@ -916,20 +916,18 @@ static uint8_t const C_cx_BLS12_381_G1_Gy[BLS12_381_SIZE_u8] = {
 // The cofactor of BLS12-381 0x396c8c005555e1568c00aaab0000aaab
 // does not fit.
 #define C_cx_BLS12_381_G1_h 1
-cx_curve_weierstrass_t const C_cx_BLS12_381_G1 = {
-  CX_CURVE_BLS12_381_G1,
-  381,
-  48,
-  (unsigned char *)C_cx_BLS12_381_G1_p,
-  (unsigned char *)C_cx_BLS12_381_G1_Hp,
-  (unsigned char *)C_cx_BLS12_381_G1_Gx,
-  (unsigned char *)C_cx_BLS12_381_G1_Gy,
-  (unsigned char *)C_cx_BLS12_381_G1_n,
-  (unsigned char *)C_cx_BLS12_381_G1_Hn,
-  C_cx_BLS12_381_G1_h,
-  (unsigned char *)C_cx_BLS12_381_G1_a,
-  (unsigned char *)C_cx_BLS12_381_G1_b
-};
+cx_curve_weierstrass_t const C_cx_BLS12_381_G1 = { CX_CURVE_BLS12_381_G1,
+                                                   381,
+                                                   48,
+                                                   C_cx_BLS12_381_G1_p,
+                                                   C_cx_BLS12_381_G1_Hp,
+                                                   C_cx_BLS12_381_G1_Gx,
+                                                   C_cx_BLS12_381_G1_Gy,
+                                                   C_cx_BLS12_381_G1_n,
+                                                   C_cx_BLS12_381_G1_Hn,
+                                                   C_cx_BLS12_381_G1_h,
+                                                   C_cx_BLS12_381_G1_a,
+                                                   C_cx_BLS12_381_G1_b };
 
 static unsigned char const C_cx_Ed25519_a[] = {
   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -995,17 +993,17 @@ static cx_curve_twisted_edward_t const C_cx_Ed25519 = {
   CX_CURVE_Ed25519,
   256,
   32,
-  (unsigned char *)C_cx_Ed25519_q,
-  (unsigned char *)C_cx_Ed25519_Hq,
-  (unsigned char *)C_cx_Ed25519_Bx,
-  (unsigned char *)C_cx_Ed25519_By,
-  (unsigned char *)C_cx_Ed25519_l,
-  (unsigned char *)C_cx_Ed25519_Hl,
+  C_cx_Ed25519_q,
+  C_cx_Ed25519_Hq,
+  C_cx_Ed25519_Bx,
+  C_cx_Ed25519_By,
+  C_cx_Ed25519_l,
+  C_cx_Ed25519_Hl,
   C_cx_Ed25519_h,
-  (unsigned char *)C_cx_Ed25519_a,
-  (unsigned char *)C_cx_Ed25519_d,
-  (unsigned char *)C_cx_Ed25519_I,
-  (unsigned char *)C_cx_Ed25519_Qplus3div8,
+  C_cx_Ed25519_a,
+  C_cx_Ed25519_d,
+  C_cx_Ed25519_I,
+  C_cx_Ed25519_Qplus3div8,
 };
 
 static cx_curve_domain_t const *const C_cx_allCurves[] = {
@@ -1208,12 +1206,12 @@ int sys_cx_ecfp_generate_pair2(cx_curve_t curve,
         errx(1, "ssl: EC_KEY_generate_key");
       }
 
-      bn = (BIGNUM *)EC_KEY_get0_private_key(key);
-      if (BN_num_bytes(bn) > (int)domain->length) {
+      const BIGNUM *priv = EC_KEY_get0_private_key(key);
+      if (BN_num_bytes(priv) > (int)domain->length) {
         errx(1, "ssl: invalid bn");
       }
       private_key->curve = curve;
-      private_key->d_len = BN_bn2bin(bn, private_key->d);
+      private_key->d_len = BN_bn2bin(priv, private_key->d);
     } else {
       BIGNUM *priv;
 
@@ -1237,8 +1235,8 @@ int sys_cx_ecfp_generate_pair2(cx_curve_t curve,
     }
 
     bn = BN_new();
-    pub = (EC_POINT *)EC_KEY_get0_public_key(key);
-    EC_POINT_point2bn(group, pub, POINT_CONVERSION_UNCOMPRESSED, bn, ctx);
+    EC_POINT_point2bn(group, EC_KEY_get0_public_key(key),
+                      POINT_CONVERSION_UNCOMPRESSED, bn, ctx);
 
     if (BN_num_bytes(bn) > 2 * (int)domain->length + 1) {
       errx(1, "ssl: invalid bn");
@@ -1441,13 +1439,13 @@ int sys_cx_ecdsa_verify(const cx_ecfp_public_key_t *key, int UNUSED(mode),
                         unsigned int hash_len, const uint8_t *sig,
                         unsigned int sig_len)
 {
-  cx_curve_weierstrass_t *domain;
+  const cx_curve_weierstrass_t *domain;
   unsigned int size;
   const uint8_t *r, *s;
   size_t rlen, slen;
   int nid = 0;
 
-  domain = (cx_curve_weierstrass_t *)cx_ecfp_get_domain(key->curve);
+  domain = (const cx_curve_weierstrass_t *)cx_ecfp_get_domain(key->curve);
   size = domain->length; // bits  -> bytes
 
   if (!cx_ecfp_decode_sig_der(sig, sig_len, size, &r, &rlen, &s, &slen)) {

--- a/src/bolos/cx_ec.h
+++ b/src/bolos/cx_ec.h
@@ -95,17 +95,17 @@ typedef enum cx_curve_e cx_curve_t;
   /** component length in bytes */                                             \
   unsigned int length;                                                         \
   /** Curve field */                                                           \
-  unsigned char *p;                                                            \
+  const unsigned char *p;                                                      \
   /** @internal 2nd Mongtomery constant for Field */                           \
-  unsigned char *Hp;                                                           \
+  const unsigned char *Hp;                                                     \
   /** Point Generator x coordinate*/                                           \
-  unsigned char *Gx;                                                           \
+  const unsigned char *Gx;                                                     \
   /** Point Generator y coordinate*/                                           \
-  unsigned char *Gy;                                                           \
+  const unsigned char *Gy;                                                     \
   /** Curve order*/                                                            \
-  unsigned char *n;                                                            \
+  const unsigned char *n;                                                      \
   /** @internal 2nd Mongtomery constant for Curve order*/                      \
-  unsigned char *Hn;                                                           \
+  const unsigned char *Hn;                                                     \
   /**  cofactor */                                                             \
   int h
 
@@ -116,9 +116,9 @@ typedef enum cx_curve_e cx_curve_t;
 struct cx_curve_weierstrass_s {
   CX_CURVE_HEADER;
   /**  a coef */
-  unsigned char *a;
+  const unsigned char *a;
   /**  b coef */
-  unsigned char *b;
+  const unsigned char *b;
 };
 
 /** Convenience type. See #cx_curve_weierstrass_s. */
@@ -130,13 +130,13 @@ typedef struct cx_curve_weierstrass_s cx_curve_weierstrass_t;
 struct cx_curve_twisted_edward_s {
   CX_CURVE_HEADER;
   /**  a coef */
-  unsigned char *a;
+  const unsigned char *a;
   /**  d coef */
-  unsigned char *d;
+  const unsigned char *d;
   /** @internal Square root of -1 or zero */
-  unsigned char *I;
+  const unsigned char *I;
   /** @internal  (q+3)/8 or (q+1)/4*/
-  unsigned char *Qq;
+  const unsigned char *Qq;
 };
 /** Convenience type. See #cx_curve_twisted_edward_s. */
 typedef struct cx_curve_twisted_edward_s cx_curve_twisted_edward_t;

--- a/src/bolos/cx_ecpoint.c
+++ b/src/bolos/cx_ecpoint.c
@@ -68,7 +68,7 @@ static cx_err_t cx_mpi_ecpoint_normalize(cx_mpi_ecpoint_t *P)
     return CX_EC_INFINITE_POINT;
   }
   if (cx_mpi_cmp_u32(P->z, 1) != 0) {
-    errx(1, "cx_mpi_ecpoint_normalize: TODO: unsupported curve (P->z=%d)",
+    errx(1, "cx_mpi_ecpoint_normalize: TODO: unsupported curve (P->z=%u)",
          cx_mpi_get_u32(P->z));
     return CX_INTERNAL_ERROR;
   }

--- a/src/bolos/cx_ed25519.c
+++ b/src/bolos/cx_ed25519.c
@@ -152,11 +152,11 @@ static void cx_compress(uint8_t *x, uint8_t *y, size_t size)
 
 int sys_cx_edward_compress_point(cx_curve_t curve, uint8_t *P, size_t P_len)
 {
-  cx_curve_twisted_edward_t *domain;
+  const cx_curve_twisted_edward_t *domain;
   uint8_t *x, *y;
   size_t size;
 
-  domain = (cx_curve_twisted_edward_t *)cx_ecfp_get_domain(curve);
+  domain = (const cx_curve_twisted_edward_t *)cx_ecfp_get_domain(curve);
   size = domain->length;
   if (curve != CX_CURVE_Ed25519 || P_len < (1 + 2 * size)) {
     errx(1, "cx_edward_compress_point: invalid parameters");
@@ -260,11 +260,11 @@ free_bn:
 
 int sys_cx_edward_decompress_point(cx_curve_t curve, uint8_t *P, size_t P_len)
 {
-  cx_curve_twisted_edward_t *domain;
+  const cx_curve_twisted_edward_t *domain;
   unsigned int size;
   uint8_t *x, *y;
 
-  domain = (cx_curve_twisted_edward_t *)cx_ecfp_get_domain(curve);
+  domain = (const cx_curve_twisted_edward_t *)cx_ecfp_get_domain(curve);
   size = domain->length;
   if (curve != CX_CURVE_Ed25519 || P_len < (1 + 2 * size)) {
     errx(1, "cx_edward_compress_point: invalid parameters");

--- a/src/bolos/cx_montgomery.c
+++ b/src/bolos/cx_montgomery.c
@@ -9,9 +9,9 @@ cx_err_t cx_montgomery_recover_y(cx_mpi_ecpoint_t *P, uint32_t sign)
   cx_mpi_t *p, *sqy, *t1, *t2, *t3;
   cx_bn_t bn_p, bn_sqy, bn_t1, bn_t2, bn_t3;
   uint32_t sz;
-  cx_curve_montgomery_t *domain;
+  const cx_curve_montgomery_t *domain;
 
-  domain = (cx_curve_montgomery_t *)cx_ecdomain(P->curve);
+  domain = (const cx_curve_montgomery_t *)cx_ecdomain(P->curve);
   if (domain == NULL) {
     return CX_INVALID_PARAMETER;
   }

--- a/src/bolos/cx_scc.c
+++ b/src/bolos/cx_scc.c
@@ -38,18 +38,18 @@ void cx_scc_struct_check_hash(const cx_hash_t *hash)
   case CX_SHA224:
 #endif
   case CX_SHA256:
-    cx_scc_assert_param(((cx_sha256_t *)hash)->blen < 64);
+    cx_scc_assert_param(((const cx_sha256_t *)hash)->blen < 64);
     return;
 
   case CX_RIPEMD160:
-    cx_scc_assert_param(((cx_ripemd160_t *)hash)->blen < 64);
+    cx_scc_assert_param(((const cx_ripemd160_t *)hash)->blen < 64);
     return;
 
 #if 0
   case CX_SHA384:
 #endif
   case CX_SHA512:
-    cx_scc_assert_param(((cx_sha512_t *)hash)->blen < 128);
+    cx_scc_assert_param(((const cx_sha512_t *)hash)->blen < 128);
     return;
 #if 0
 
@@ -82,9 +82,9 @@ void cx_scc_struct_check_hash(const cx_hash_t *hash)
 #endif
 
   case CX_BLAKE2B: {
-    os = ((cx_blake2b_t *)hash)->output_size;
+    os = ((const cx_blake2b_t *)hash)->output_size;
     cx_scc_assert_param((os >= 8 / 8) && (os <= 512 / 8));
-    struct blake2b_state__ *ctx = &((cx_blake2b_t *)hash)->ctx;
+    const struct blake2b_state__ *ctx = &((const cx_blake2b_t *)hash)->ctx;
     cx_scc_assert_param((ctx->buflen <= BLAKE2B_BLOCKBYTES) &&
                         (ctx->outlen <= BLAKE2B_BLOCKBYTES));
   }
@@ -111,7 +111,7 @@ void cx_scc_struct_check_hashmac(const cx_hmac_t *hmac)
       && hash_algorithm != CX_SHA512 && hash_algorithm != CX_RIPEMD160) {
     THROW(INVALID_PARAMETER);
   }
-  cx_scc_struct_check_hash((cx_hash_t *)&hmac->hash_ctx);
+  cx_scc_struct_check_hash((const cx_hash_t *)&hmac->hash_ctx);
 }
 
 #if 0

--- a/src/bolos/cx_twisted_edwards.c
+++ b/src/bolos/cx_twisted_edwards.c
@@ -9,9 +9,9 @@ cx_err_t cx_twisted_edwards_recover_x(cx_mpi_ecpoint_t *P, uint32_t sign)
   cx_mpi_t *p, *t1, *t2, *t3;
   cx_bn_t bn_p, bn_t1, bn_t2, bn_t3;
   uint32_t sz;
-  cx_curve_twisted_edwards_t *domain;
+  const cx_curve_twisted_edwards_t *domain;
 
-  domain = (cx_curve_twisted_edwards_t *)cx_ecdomain(P->curve);
+  domain = (const cx_curve_twisted_edwards_t *)cx_ecdomain(P->curve);
   if (domain == NULL) {
     return CX_INVALID_PARAMETER;
   }

--- a/src/bolos/cx_weierstrass.c
+++ b/src/bolos/cx_weierstrass.c
@@ -9,9 +9,9 @@ cx_err_t cx_weierstrass_recover_y(cx_mpi_ecpoint_t *P, uint32_t sign)
   cx_mpi_t *p, *sqy, *t1, *t2;
   cx_bn_t bn_p, bn_sqy, bn_t1, bn_t2;
   uint32_t sz;
-  cx_curve_montgomery_t *domain;
+  const cx_curve_weierstrass_t *domain;
 
-  domain = (cx_curve_montgomery_t *)cx_ecdomain(P->curve);
+  domain = (const cx_curve_weierstrass_t *)cx_ecdomain(P->curve);
   if (domain == NULL) {
     return CX_INVALID_PARAMETER;
   }

--- a/src/bolos/os.c
+++ b/src/bolos/os.c
@@ -206,7 +206,7 @@ unsigned long sys_check_api_level(void)
 
 unsigned long sys_os_sched_exit(unsigned int code)
 {
-  fprintf(stderr, "[*] exit called (%d)\n", code);
+  fprintf(stderr, "[*] exit called (%u)\n", code);
   _exit(0);
 }
 

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -39,7 +39,7 @@ int emulate(unsigned long syscall, unsigned long *parameters,
     retid = emulate_blue_2_2_5(syscall, parameters, ret, verbose);
     break;
   default:
-    errx(1, "Unsupported SDK version %i", version);
+    errx(1, "Unsupported SDK version %u", version);
     break;
   }
   return retid;
@@ -56,7 +56,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL6(cx_aes, "(%p, 0x%x, %p, %u, %p, %u)",
            const cx_aes_key_t *, key,
-           int,                  mode,
+           unsigned int,         mode,
            const uint8_t *,      in,
            unsigned int,         len,
            uint8_t *,            out,
@@ -64,7 +64,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
            const cx_aes_key_t *, key,
-           int,                  mode,
+           unsigned int,         mode,
            const uint8_t *,      iv,
            unsigned int,         iv_len,
            const uint8_t *,      in,
@@ -100,9 +100,9 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
           uint8_t *,                     secret,
           size_t,                        secret_len);
 
-  SYSCALL8(cx_ecdsa_sign, "(%p, 0x%x, %d, %p, %u, %p, %u, %p)",
+  SYSCALL8(cx_ecdsa_sign, "(%p, 0x%x, %u, %p, %u, %p, %u, %p)",
            const cx_ecfp_private_key_t *, key,
-           int,                           mode,
+           unsigned int,                  mode,
            cx_md_t,                       hashID,
            const uint8_t *,               hash,
            unsigned int,                  hash_len,
@@ -110,9 +110,9 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
            unsigned int,                  sig_len,
            unsigned int *,                info);
 
-  SYSCALL7(cx_ecdsa_verify, "(%p, 0x%x, %d, %p, %u, %p, %u)",
+  SYSCALL7(cx_ecdsa_verify, "(%p, 0x%x, %u, %p, %u, %p, %u)",
            const cx_ecfp_public_key_t *, key,
-           int,                          mode,
+           unsigned int,                 mode,
            cx_md_t,                      hashID,
            const uint8_t *,              hash,
            unsigned int,                 hash_len,
@@ -132,7 +132,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
            cx_ecfp_private_key_t *, private_key,
            int,                     keep_private);
 
-  SYSCALL5(cx_ecfp_generate_pair2, "(0x%x, %p, %p, %d, %d)",
+  SYSCALL5(cx_ecfp_generate_pair2, "(0x%x, %p, %p, %d, %u)",
           cx_curve_t,              curve,
           cx_ecfp_public_key_t *,  public_key,
           cx_ecfp_private_key_t *, private_key,
@@ -165,7 +165,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL10(cx_eddsa_sign, "(%p, 0x%x, 0x%x, %p, %u, %p, %u, %p, %u, %p)",
             const cx_ecfp_private_key_t *, pvkey,
-            int,                           mode,
+            unsigned int,                  mode,
             cx_md_t,                       hashID,
             const unsigned char *,         hash,
             unsigned int,                  hash_len,
@@ -177,7 +177,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL9(cx_eddsa_verify, "(%p, 0x%x, 0x%x, %p, %u, %p, %u, %p, %u)",
            const cx_ecfp_public_key_t *, pu_key,
-           int,                          mode,
+           unsigned int,                 mode,
            cx_md_t,                      hashID,
            const unsigned char *,        hash,
            unsigned int,                 hash_len,
@@ -198,7 +198,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL6(cx_hash, "(%p, 0x%x, %p, %u, %p, %u)",
            cx_hash_t *,     hash,
-           int,             mode,
+           unsigned int,    mode,
            const uint8_t *, in,
            size_t,          len,
            uint8_t *,       out,
@@ -218,7 +218,7 @@ int emulate_common(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL6(cx_hmac, "(%p, 0x%x, %p, %u, %p, %u)",
            cx_hmac_t *,     hmac,
-           int,             mode,
+           unsigned int,    mode,
            const uint8_t *, in,
            unsigned int,    len,
            uint8_t *,       out,

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -15,10 +15,10 @@
 #include "bolos_syscalls_1.5.h"
 
 int emulate(unsigned long syscall, unsigned long *parameters,
-            unsigned long *ret, bool verbose, sdk_version_t sdk_version)
+            unsigned long *ret, bool verbose, sdk_version_t version)
 {
   int retid = 0;
-  switch (sdk_version) {
+  switch (version) {
   case SDK_NANO_X_1_2:
     retid = emulate_1_2(syscall, parameters, ret, verbose);
     break;
@@ -39,7 +39,7 @@ int emulate(unsigned long syscall, unsigned long *parameters,
     retid = emulate_blue_2_2_5(syscall, parameters, ret, verbose);
     break;
   default:
-    errx(1, "Unsupported SDK version %i", sdk_version);
+    errx(1, "Unsupported SDK version %i", version);
     break;
   }
   return retid;

--- a/src/emulate.h
+++ b/src/emulate.h
@@ -158,7 +158,7 @@ unsigned long sys_os_lib_throw(unsigned int exception);
 #define print_ret(ret)                                                         \
   do {                                                                         \
     if (verbose) {                                                             \
-      fprintf(stderr, " = %ld (0x%lx)\n", ret, ret);                           \
+      fprintf(stderr, " = %lu (0x%lx)\n", ret, ret);                           \
     }                                                                          \
   } while (0)
 

--- a/src/emulate_1.2.c
+++ b/src/emulate_1.2.c
@@ -108,7 +108,7 @@ int emulate_1_2(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
            const cx_aes_key_t *, key,
-           int,                  mode,
+           unsigned int,         mode,
            const uint8_t *,      iv,
            unsigned int,         iv_len,
            const uint8_t *,      in,

--- a/src/emulate_1.5.c
+++ b/src/emulate_1.5.c
@@ -56,7 +56,7 @@ int emulate_1_5(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
            const cx_aes_key_t *, key,
-           int,                  mode,
+           unsigned int,         mode,
            const uint8_t *,      iv,
            unsigned int,         iv_len,
            const uint8_t *,      in,

--- a/src/emulate_1.6.c
+++ b/src/emulate_1.6.c
@@ -82,7 +82,7 @@ int emulate_1_6(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
            const cx_aes_key_t *, key,
-           int,                  mode,
+           unsigned int,         mode,
            const uint8_t *,      iv,
            unsigned int,         iv_len,
            const uint8_t *,      in,

--- a/src/emulate_blue_2.2.5.c
+++ b/src/emulate_blue_2.2.5.c
@@ -54,7 +54,7 @@ int emulate_blue_2_2_5(unsigned long syscall, unsigned long *parameters,
 
   SYSCALL8(cx_aes_iv, "(%p, 0x%x, %p, %u, %p, %u, %p, %u)",
            const cx_aes_key_t *, key,
-           int,                  mode,
+           unsigned int,         mode,
            const uint8_t *,      iv,
            unsigned int,         iv_len,
            const uint8_t *,      in,

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -225,14 +225,14 @@ static void *load_app(char *name)
   }
 
   if (app->elf.load_offset > st.st_size) {
-    warnx("app load offset is larger than file size (%ld > %lld)\n",
+    warnx("app load offset is larger than file size (%lu > %lld)\n",
           app->elf.load_offset, st.st_size);
     goto error;
   }
 
   size = app->elf.load_size;
   if (size > st.st_size - app->elf.load_offset) {
-    warnx("app load size is larger than file size (%ld > %lld)\n",
+    warnx("app load size is larger than file size (%lu > %lld)\n",
           app->elf.load_size, st.st_size);
     goto error;
   }


### PR DESCRIPTION
Add several compilation flags that check for format strings and qualifiers.

`-Werror` has also been added to forbid warnings during compilation.