### PR TITLE
[fix][#282] 

### DIFF
--- a/speculos/api/events.py
+++ b/speculos/api/events.py
@@ -67,7 +67,7 @@ class Events(AppResource):
             raise RuntimeError("Argument 'automation_server' must not be None")
         self._broadcaster = automation_server
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument("stream", type=inputs.boolean, default=False)
+        self.parser.add_argument("stream", type=inputs.boolean, default=False, location='values')
         super().__init__(*args, **kwargs)
 
     def get(self):


### PR DESCRIPTION
Werkzeug version >= 2.1 will raise if accessing  field whereas the request content is not declared as application/json.

So for a simple `get` with no embedded data but a trivial query arg (`/events?stream=True`), specifying to look for argument as values should do. 