### PR TITLE
[ci][fix] Sharing Python venv between build job and upload job

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -119,8 +119,8 @@ jobs:
         name: dist
         path: dist
 
-  deploy_python_package:
-    name: Deploy the Speculos Python package
+  deploy_python_package_and_docker:
+    name: Deploy the Speculos Python package and Speculos build Docker
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [package_python]
@@ -131,6 +131,10 @@ jobs:
       with:
         name: dist
         path: dist
+    - name: Creating venv & installing dependencies
+      run: |
+        python3 -m venv venv-build
+        ./venv-build/bin/pip install --upgrade pip build twine
 
     # TEST_PYPI_API_TOKEN is an API token created on
     # https://test.pypi.org/manage/account/#api-tokens with restriction to speculos project


### PR DESCRIPTION
Latest merged [PR](https://github.com/LedgerHQ/speculos/pull/284) broke the CI: the python venv is not present in the last step, when uploading the new Speculos package.

This PR upload the venv as an artifact to use it in the last job.

We could use cache, but I'm not sure how the cache mechanism is updated with newer versions (which could easily break in Python, [see this issue](https://github.com/LedgerHQ/speculos/issues/282)) in GitHub, and generally I don't trust caches. I'm open to opinions.