### PR TITLE
[ci][fix] The docker image needs to embed ressource files

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -77,14 +77,8 @@ jobs:
         make -C build/ test
         python3 -m pytest
 
-    - name: Use pip to install speculos in a virtual environment
-      run: |
-        python3 -m venv venv-test
-        ./venv-test/bin/pip install .
-        ./venv-test/bin/speculos --help
-
   package_python:
-    name: Package Speculos
+    name: Package Speculos and deploy Python Package & docker
     runs-on: ubuntu-latest
     needs: [build, coverage]
     # Use https://ghcr.io/ledgerhq/speculos-builder which has all the required
@@ -97,6 +91,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: Use pip to install Speculos in a virtual environment
+      run: |
+        python3 -m venv venv-test
+        ./venv-test/bin/pip install .
+        ./venv-test/bin/speculos --help
 
     # Use commands from https://packaging.python.org/tutorials/packaging-projects/
     # to build the Speculos package, but using a dedicated virtual environment
@@ -113,32 +113,11 @@ jobs:
         ./venv-build/bin/pip install --upgrade pip build twine
         ./venv-build/bin/python -m build
         ./venv-build/bin/python -m twine check dist/*
-    - name: Upload python package
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: dist
-
-  deploy_python_package_and_docker:
-    name: Deploy the Speculos Python package and Speculos build Docker
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    needs: [package_python]
-
-    steps:
-    - name: Download app binary
-      uses: actions/download-artifact@v2
-      with:
-        name: dist
-        path: dist
-    - name: Creating venv & installing dependencies
-      run: |
-        python3 -m venv venv-build
-        ./venv-build/bin/pip install --upgrade pip build twine
 
     # TEST_PYPI_API_TOKEN is an API token created on
     # https://test.pypi.org/manage/account/#api-tokens with restriction to speculos project
     - name: Publish Python package to test.pypi.org
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
         ./venv-build/bin/python -m twine upload --repository testpypi dist/*
       env:
@@ -146,11 +125,8 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         TWINE_NON_INTERACTIVE: 1
 
-    - name: Clone
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Build and publish to GitHub Packages
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v1
       with:
         repository: ledgerhq/speculos


### PR DESCRIPTION
The docker need the `speculos/resources/` directory to be created and present to work. This is created when performing a `pip install ` of Speculos, so this code move this step from the `build` step (where it wasn't that useful) to the `package_python` step.