### PR TITLE
ci: update build-push-action version

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -125,40 +125,11 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         TWINE_NON_INTERACTIVE: 1
 
-#  package_and_test_docker:
-#    name: Build and test the Speculos docker
-#    runs-on: ubuntu-latest
-#    container:
-#      image: docker://ghcr.io/ledgerhq/speculos-builder:sha-9459c1d
-#    steps:
-#    - name: Clone
-#      uses: actions/checkout@v2
-#      with:
-#        fetch-depth: 0
-#    - name: Set up Docker Buildx
-#      id: buildx
-#      uses: docker/setup-buildx-action@v2
-#    - name: Build the Speculos docker
-#      uses: docker/build-push-action@v2
-#      with:
-#        platforms: linux/amd64
-#        push: false
-#        tags: speculos:test-image
-#    - name: Run and test Speculos docker
-#      uses: addnab/docker-run-action@v3
-#      with:
-#        image: speculos:test-image
-#        options: -v ${{ github.workspace }}/apps/:/apps/
-#        run: |
-#          apt-get update && apt-get install -qy netcat
-#          /speculos/speculos.py /apps/btc.elf --display=headless  --apdu-port 9999 &
-#          until `nc -w5 -z -v 127.0.0.1 9999`; do sleep 1; done;
-
-  deploy_docker:
-    name: Build and Upload the Speculos docker
+  build_test_publish_docker_image:
+    name: Build, test and publish the docker image
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [package_python] # package_and_test_docker
+    container:
+      image: docker://ghcr.io/ledgerhq/speculos-builder:sha-9459c1d
     steps:
     - name: Clone
       uses: actions/checkout@v2
@@ -167,14 +138,29 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
-    - name: Build and publish to GitHub Packages
+    - name: Build the Speculos docker
       uses: docker/build-push-action@v3
       with:
-        builder: ${{ steps.buildx.outputs.name }}
+        load: true
+        tags: speculos:test-image
+    - name: Run and test Speculos docker
+      uses: docker/build-push-action@v3
+      with:
+        image: speculos:test-image
+        options: --rm -v ${{ github.workspace }}/apps/:/apps/
+        run: |
+          apt-get update && apt-get install -qy netcat
+          /speculos/speculos.py /apps/btc.elf --display=headless  --apdu-port 9999 &
+          until `nc -w5 -z -v 127.0.0.1 9999`; do sleep 1; done;
+    - name: Build and publish to GitHub Packages
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         platforms: linux/amd64,linux/arm64
+        push: true
         tags: ledgerhq/speculos:latest
 
   coverage:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -139,7 +139,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v2
     - name: Build the Speculos docker
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v3
       with:
         builder: ${{ steps.buildx.outputs.name }}
         platforms: linux/amd64,linux/arm64
@@ -169,16 +169,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v2
     - name: Build and publish to GitHub Packages
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v3
       with:
         builder: ${{ steps.buildx.outputs.name }}
-        repository: ledgerhq/speculos
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        tag_with_sha: true
         platforms: linux/amd64,linux/arm64
-        tags: latest
+        tags: ledgerhq/speculos:latest
 
   coverage:
     name: Code coverage

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -125,40 +125,40 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         TWINE_NON_INTERACTIVE: 1
 
-  package_and_test_docker:
-    name: Build and test the Speculos docker
-    runs-on: ubuntu-latest
-    container:
-      image: docker://ghcr.io/ledgerhq/speculos-builder:latest
-    steps:
-    - name: Clone
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
-    - name: Build the Speculos docker
-      uses: docker/build-push-action@v3
-      with:
-        platforms: linux/amd64
-        push: false
-        tags: speculos:test-image
-    - name: Run and test Speculos docker
-      uses: addnab/docker-run-action@v3
-      with:
-        image: speculos:test-image
-        options: -v ${{ github.workspace }}/apps/:/apps/
-        run: |
-          apt-get update && apt-get install -qy netcat
-          /speculos/speculos.py /apps/btc.elf --display=headless  --apdu-port 9999 &
-          until `nc -w5 -z -v 127.0.0.1 9999`; do sleep 1; done;
+#  package_and_test_docker:
+#    name: Build and test the Speculos docker
+#    runs-on: ubuntu-latest
+#    container:
+#      image: docker://ghcr.io/ledgerhq/speculos-builder:latest
+#    steps:
+#    - name: Clone
+#      uses: actions/checkout@v2
+#      with:
+#        fetch-depth: 0
+#    - name: Set up Docker Buildx
+#      id: buildx
+#      uses: docker/setup-buildx-action@v2
+#    - name: Build the Speculos docker
+#      uses: docker/build-push-action@v2
+#      with:
+#        platforms: linux/amd64
+#        push: false
+#        tags: speculos:test-image
+#    - name: Run and test Speculos docker
+#      uses: addnab/docker-run-action@v3
+#      with:
+#        image: speculos:test-image
+#        options: -v ${{ github.workspace }}/apps/:/apps/
+#        run: |
+#          apt-get update && apt-get install -qy netcat
+#          /speculos/speculos.py /apps/btc.elf --display=headless  --apdu-port 9999 &
+#          until `nc -w5 -z -v 127.0.0.1 9999`; do sleep 1; done;
 
   deploy_docker:
     name: Build and Upload the Speculos docker
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [package_and_test_docker, package_python]
+    needs: [package_python] # package_and_test_docker
     steps:
     - name: Clone
       uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -141,14 +141,13 @@ jobs:
     - name: Build the Speculos docker
       uses: docker/build-push-action@v3
       with:
-        builder: ${{ steps.buildx.outputs.name }}
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: false
-        tags: test
+        tags: speculos:test-image
     - name: Run and test Speculos docker
       uses: addnab/docker-run-action@v3
       with:
-        image: ledgerhq/speculos:test
+        image: speculos:test-image
         options: -v ${{ github.workspace }}/apps/:/apps/
         run: |
           apt-get update && apt-get install -qy netcat

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -57,7 +57,7 @@ jobs:
     # Use https://ghcr.io/ledgerhq/speculos-builder which has all the required
     # dependencies
     container:
-      image: docker://ghcr.io/ledgerhq/speculos-builder:latest
+      image: docker://ghcr.io/ledgerhq/speculos-builder:sha-9459c1d
 
     steps:
     - name: Clone
@@ -129,7 +129,7 @@ jobs:
 #    name: Build and test the Speculos docker
 #    runs-on: ubuntu-latest
 #    container:
-#      image: docker://ghcr.io/ledgerhq/speculos-builder:latest
+#      image: docker://ghcr.io/ledgerhq/speculos-builder:sha-9459c1d
 #    steps:
 #    - name: Clone
 #      uses: actions/checkout@v2
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linter, misspell]
     container:
-      image: docker://ghcr.io/ledgerhq/speculos-builder:latest
+      image: docker://ghcr.io/ledgerhq/speculos-builder:sha-9459c1d
     steps:
     - name: Clone
       uses: actions/checkout@v2

--- a/.github/workflows/speculos-builder.yml
+++ b/.github/workflows/speculos-builder.yml
@@ -26,14 +26,12 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build and push speculos-builder to GitHub Packages
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v3
       with:
         builder: ${{ steps.buildx.outputs.name }}
         dockerfile: build.Dockerfile
         platforms: linux/amd64,linux/arm64
-        repository: ledgerhq/speculos-builder
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        tag_with_sha: true
-        tags: latest
+        tags: ledgerhq/speculos-builder:latest

--- a/.github/workflows/speculos-builder.yml
+++ b/.github/workflows/speculos-builder.yml
@@ -28,9 +28,9 @@ jobs:
     - name: Build and push speculos-builder to GitHub Packages
       uses: docker/build-push-action@v3
       with:
-        builder: ${{ steps.buildx.outputs.name }}
         dockerfile: build.Dockerfile
         platforms: linux/amd64,linux/arm64
+        push: true
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous commit (PR #292) added support for Mac M1 by adding docker images for the AARCH64 architecture. However, it requires a more recent [version](https://github.com/docker/build-push-action/releases/tag/v2.0.0) of `build-push-action` to be effective and support `builder` and `platforms` inputs.

FTR, there are warnings in CI annotations [2331145006](https://github.com/LedgerHQ/speculos/actions/runs/2331145006) and [2331145005](https://github.com/LedgerHQ/speculos/actions/runs/2331145006)