### PR TITLE
Revert "Build Docker image wit Mac M1 chipset support"

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -135,14 +135,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
     - name: Build the Speculos docker
       uses: docker/build-push-action@v1
       with:
-        builder: ${{ steps.buildx.outputs.name }}
-        platforms: linux/amd64,linux/arm64
         push: false
         tags: test
     - name: Run and test Speculos docker
@@ -165,19 +160,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
     - name: Build and publish to GitHub Packages
       uses: docker/build-push-action@v1
       with:
-        builder: ${{ steps.buildx.outputs.name }}
         repository: ledgerhq/speculos
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         tag_with_sha: true
-        platforms: linux/amd64,linux/arm64
         tags: latest
 
   coverage:

--- a/.github/workflows/speculos-builder.yml
+++ b/.github/workflows/speculos-builder.yml
@@ -21,16 +21,10 @@ jobs:
     - name: Clone
       uses: actions/checkout@v2
 
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
-
     - name: Build and push speculos-builder to GitHub Packages
       uses: docker/build-push-action@v1
       with:
-        builder: ${{ steps.buildx.outputs.name }}
         dockerfile: build.Dockerfile
-        platforms: linux/amd64,linux/arm64
         repository: ledgerhq/speculos-builder
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/src/vnc/CMakeLists.txt
+++ b/src/vnc/CMakeLists.txt
@@ -4,10 +4,6 @@ project(VncServer C)
 
 add_compile_options(-Wall)
 
-if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
-    add_compile_options(-DDISABLE_SANDBOX)
-endif ()
-
 add_executable(vnc_server vnc_server.c cursor.c)
 # add DISABLE_SANDBOX to build vnc_server without seccomp-bpf
 target_compile_definitions(vnc_server PRIVATE CUSTOM_CURSOR)


### PR DESCRIPTION
This reverts commit b64d28d2df793ad3733c9db1a6946331e6d94502 which seems to have
pushed linux/aarch64 docker images to ghcr.io (while linux/amd64 and aarch64
images were expected).

This commit was introduced by the PR #292 which add support for Mac M1 by adding
docker images for the AARCH64 architecture. However, it requires a more recent
version of build-push-action to be effective and upgrading to a new version
isn't straightforward.