### PR TITLE
link for external developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ between the app and the syscalls. This doesn't reflect the security of the
 firmware on hardware devices where app and OS isolation is enforced.
 
 Speculos is not part of Ledger bug bounty program.
+
+
+## Are you developing a Nano App as an external developer?
+
+For a smooth and quick integration:
+- Follow the developers documentation on the [Developer Portal](https://developers.ledger.com/docs/nano-app/introduction/) and 
+- Go on Discord to chat with developper support and the developper community. See you there! If you are new to Ledger OP3N Discord server [click here](), otherwise directly join [the Nano App channel](https://discord.com/channels/885256081289379850/907623554542080070).
+
+


### PR DESCRIPTION
Hello, 
It sometimes happen that external developers work on their integration without knowing there is a developer portal. That is why I would like to add this paragraph to the documentation. What do you think?