### PR TITLE
disable gdbinit usage for Mac M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN pipenv install --deploy --system
 RUN apt-get update && apt-get install -qy \
     qemu-user-static \
     libvncserver-dev \
+    gdb-multiarch \
     && apt-get clean
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/

--- a/tools/debug.sh
+++ b/tools/debug.sh
@@ -24,8 +24,14 @@ function main()
     launcher_text_addr=$(get_text_addr "$launcher_path")
     local gdbinit="$script_dir/gdbinit"
 
-    cat >/tmp/x.gdb<<EOF
+    local arch
+    arch=$(uname -m)
+    if [ "$arch" != "aarch64" ]; then
+        cat >/tmp/x.gdb<<EOF
 source ${gdbinit}
+EOF
+    fi
+    cat >>/tmp/x.gdb<<EOF
 set architecture arm
 target remote 127.0.0.1:1234
 handle SIGILL nostop pass noprint
@@ -34,7 +40,6 @@ add-symbol-file "${app}" 0x40000000
 b *0x40000000
 c
 EOF
-
     "${GDB}" -q -nh -x /tmp/x.gdb
 }
 


### PR DESCRIPTION
When using gdb with Mac M1, disable gdbinit usage