### PR TITLE
automatically define NATIVE_64BITS on 64-bit CPUs

### DIFF
--- a/src/bolos/cx_utils.h
+++ b/src/bolos/cx_utils.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#if UINTPTR_MAX == UINT64_MAX
+#define NATIVE_64BITS
+#endif
+
 #ifndef NATIVE_64BITS // NO 64BITS
 /** 64bits types, native or by-hands, depending on target and/or compiler
  * support.


### PR DESCRIPTION
Predefining NATIVE_64BITS leads to a redefinition if speculos source files are
built with cxlib:

https://github.com/LedgerHQ/nanox-secure-sdk/blob/86324f6a73e269c04f6a3e3cf41f6569a8cc6c6b/lib_cxng/include/lcx_common.h#L38