### PR TITLE
bump flask-restful minimum version to 0.3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "construct>=2.10.56,<3.0.0",
         "flask>=2.0.0,<3.0.0",
-        "flask-restful>=0.3.8,<1.0",
+        "flask-restful>=0.3.9,<1.0",
         "jsonschema>=3.2.0,<4.0.0",
         "mnemonic>=0.19,<1.0",
         "pillow>=8.0.0,<10.0.0",


### PR DESCRIPTION
flask-restful 0.3.8 is incompatible with Flask 2.0, or speculos requires at least Flask 2.0.0.