### PR TITLE
codespell: ignore globalY

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -1,3 +1,4 @@
+globaly
 keypair
 ontop
 tolen


### PR DESCRIPTION
codespell reports a false-positive mispelling:

    speculos/mcu/screen.py:170: globalY ==> globally

Ignore this by adding this word to `.codespell-ignore`.