### PR TITLE
Add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+let
+  pkgs = import <nixpkgs> {};
+  pythonWithPkgs = pkgs.python3.withPackages (pp: with pp; [
+    pyqt5
+    construct
+    jsonschema
+    flask-restful
+    pillow
+    requests
+    mnemonic
+    pyelftools
+    setuptools            # for pkg_resources
+  ]);
+  qemuWrapper = pkgs.writeShellScriptBin "qemu-arm-static" ''
+    exec ${pkgs.qemu}/bin/qemu-arm "$@"
+  '';
+  speculos = import ./speculos.nix;
+in pkgs.mkShell {
+  buildInputs = [
+    pythonWithPkgs
+    qemuWrapper
+  ];
+
+  shellHook = ''
+    mkdir -p ./speculos/resources/
+    cp ${speculos}/launcher ./speculos/resources/
+  '';
+
+  QT_QPA_PLATFORM_PLUGIN_PATH="${pkgs.qt5.qtbase.bin}/lib/qt-${pkgs.qt5.qtbase.version}/plugins";
+}

--- a/speculos.nix
+++ b/speculos.nix
@@ -1,0 +1,26 @@
+with import <nixpkgs> {};
+let
+  crossSystem = pkgsCross.armv7l-hf-multiplatform;
+  crossOpenssl = (crossSystem.pkgs.openssl.override {
+    static = true;
+  });
+  gccWrapper = writeShellScriptBin "arm-linux-gnueabihf-gcc" ''
+    exec ${crossSystem.stdenv.cc}/bin/armv7l-unknown-linux-gnueabihf-gcc "$@"
+  '';
+in
+crossSystem.stdenv.mkDerivation {
+  name = "speculos";
+  nativeBuildInputs = [ cmake gccWrapper ];
+  buildInputs = [
+    crossOpenssl
+    crossSystem.pkgs.glibc.static
+  ];
+
+  src = ./.;
+  cmakeFlags = "-D PRECOMPILED_DEPENDENCIES_DIR=${lib.getLib crossOpenssl}/lib";
+
+  installPhase = ''
+    mkdir -p $out/
+    cp ./src/launcher $out/
+  '';
+}


### PR DESCRIPTION
Under NixOS running `nix-shell` within the speculos directory will automatically compile the launcher and prepare an environment with qemu, python3 and all the required python dependencies.

VNC is currently not supported.

Note that the `launcher` alone can also be compiled by running `nix-build ./speculos.nix`, if the emulation environment is not required.