### PR TITLE
Load entire segment containing `.text`

### DIFF
--- a/speculos/main.py
+++ b/speculos/main.py
@@ -50,10 +50,18 @@ def get_elf_infos(app_path):
     with open(app_path, 'rb') as fp:
         elf = ELFFile(fp)
         text = elf.get_section_by_name('.text')
+        for seg in elf.iter_segments():
+            if seg['p_type'] != 'PT_LOAD':
+                continue
+            if seg.section_in_segment(text):
+                text_seg = seg
+                break;
+        else:
+            raise RuntimeError("No program header with text section!")
         symtab = elf.get_section_by_name('.symtab')
         bss = elf.get_section_by_name('.bss')
-        sh_offset = text['sh_offset']
-        sh_size = text['sh_size']
+        sh_offset = text_seg['p_offset']
+        sh_size = text_seg['p_filesz']
         stack = bss['sh_addr']
         sym_estack = symtab.get_symbol_by_name('_estack')
         if sym_estack is None:

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -55,7 +55,7 @@ def get_elf_infos(app_path):
                 continue
             if seg.section_in_segment(text):
                 text_seg = seg
-                break;
+                break
         else:
             raise RuntimeError("No program header with text section!")
         symtab = elf.get_section_by_name('.symtab')


### PR DESCRIPTION
Do this instead of just loading the section itself.

Sections are just for linking purposes and not needed at runtime with a completely linked app. Segments (corresponding to program headers), on the other hand, are the actual important runtime data for what should be loaded. It is therefore more correct to load or not load whole sections than individual segments.

We have successfully tried out various linker tricks, in order to have things like properly initialized globals and relocations to reflect apps install-time address on the flash. This is a small step that makes it easier to use speculos which such experiments.

We would be happy to further improve speculos on this front, e.g. to make it load multiple program headers provided they are adjacent, or also load "hex" files (to be more realistic to how the "production" workflow is without arbitrary ELF tricks). But both of these are more involved, so we figured it was better to start with something very simple.