### PR TITLE
Propagate app's exit status

### DIFF
--- a/speculos.py
+++ b/speculos.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Launch Speculos emulator"""
+import sys
 from speculos.main import main
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -82,7 +82,7 @@ def get_cx_infos(app_path):
     return sh_offset, sh_size, sh_load, cx_ram_size, cx_ram_load
 
 
-def run_qemu(s1: socket.socket, s2: socket.socket, args: argparse.Namespace) -> None:
+def run_qemu(s1: socket.socket, s2: socket.socket, args: argparse.Namespace) -> int:
     argv = ['qemu-arm-static']
 
     if args.debug:
@@ -127,7 +127,7 @@ def run_qemu(s1: socket.socket, s2: socket.socket, args: argparse.Namespace) -> 
 
     pid = os.fork()
     if pid != 0:
-        return
+        return pid
 
     # ensure qemu is killed when this Python script exits
     set_pdeath(signal.SIGTERM)
@@ -298,7 +298,7 @@ def main(prog=None):
 
     s1, s2 = socket.socketpair()
 
-    run_qemu(s1, s2, args)
+    qemu_pid = run_qemu(s1, s2, args)
     s1.close()
 
     apdu = apdu_server.ApduServer(host="0.0.0.0", port=args.apdu_port)
@@ -348,3 +348,6 @@ def main(prog=None):
     screen.run()
 
     s2.close()
+    _, status = os.waitpid(qemu_pid, 0)
+    qemu_exit_status = os.WEXITSTATUS(status)
+    return qemu_exit_status

--- a/src/bolos/os.c
+++ b/src/bolos/os.c
@@ -207,7 +207,7 @@ unsigned long sys_check_api_level(void)
 unsigned long sys_os_sched_exit(unsigned int code)
 {
   fprintf(stderr, "[*] exit called (%u)\n", code);
-  _exit(0);
+  _exit(code);
 }
 
 unsigned long sys_reset(void)


### PR DESCRIPTION
In order to easily detect whether the emulated app exited successfully or not, it is necessary to use the exit `code` in the actual call to `_exit`.
This is not necessary in most cases as bolos ignores this exit code, but enables easier testing in CI: if the test calls `os_sched_exit` with a non-zero status, the CI can tell it failed directly.