### PR TITLE
Fallback syscall emulation to common for LNS+

### DIFF
--- a/src/emulate_lnsp_1.0.c
+++ b/src/emulate_lnsp_1.0.c
@@ -315,7 +315,7 @@ int emulate_nanosp_1_0(unsigned long syscall, unsigned long *parameters,
              unsigned char, index, unsigned char *, buffer);
 
   default:
-    fprintf(stderr, "syscall 0x%08lx not handled\n", syscall);
+    emulate_common(syscall, parameters, ret, verbose);
     break;
   }
   /* retid is no longer used in SDK 2.0 */


### PR DESCRIPTION
LNS+ emulation ended with an error if the syscall used was a 'common' one with other platforms, instead of forwarding the call to `emulate_common` like other platforms.