### PR TITLE
Improve ocr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=builder /speculos/speculos/resources/ /speculos/speculos/resources/
 
 RUN pip install --upgrade pip pipenv
 RUN pipenv install --deploy --system
-RUN pip install pytesseract
+RUN pip install pytesseract opencv-python-headless numpy
 
 
 RUN apt-get update && apt-get install -qy \

--- a/docs/installation/build.md
+++ b/docs/installation/build.md
@@ -15,7 +15,7 @@ sudo apt install \
     python3-mnemonic python3-pil python3-pyelftools python3-requests \
     qemu-user-static tesseract-ocr libtesseract-dev
 
-pip install pytesseract
+pip install pytesseract opencv-python-headless numpy
 ```
 
 For optional VNC support, please also install `libvncserver-dev`:

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -90,11 +90,20 @@ Launch the Bitcoin Testnet app, which requires the Bitcoin app:
 ./speculos.py ./apps/btc-test.elf -l Bitcoin:./apps/btc.elf
 ```
 
-## OCR
+## Optical Character Recognition
 
-OCR is available for NanoX with built in character recognition.
+Optical Character Recognition (OCR) allows to detect text displayed on the device's screen.
+The detected text is then available as "events" (cf. Speculos REST API documentation).
 
-Stax makes use of the Tessseract library for OCR, with known issues for detecting inverted text. 
+### Nano X, Nano SP
 
-Launching Speculos with `--force-full-ocr` flag forces all text to be written in black over a white background,
-having an visible effect on the display but solving the latter issue.
+Two modes are available :
+
+* Legacy (with `--legacy-ocr` command line argument) : uses font bitmaps to detect
+  text. Fast but can result in some characters not being detected.
+* Default : uses the [Tesseract](https://github.com/tesseract-ocr/tesseract) engine.
+  Slower but recognizes text without the need for font bitmaps.
+
+### Stax
+
+Stax makes use of the Tessseract library for OCR by default.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ setup(
         "pyqt5>=5.15.2,<6.0.0",
         "requests>=2.25.1,<3.0.0",
         "pytesseract>=0.3.10,<0.4.0",
+        "opencv-python-headless>=4.6.0,<5.0.0",
+        "numpy>=1.23.5,<1.24.0",
     ]
     + (["dataclasses>=0.8,<0.9"] if sys.version_info <= (3, 6) else []),
     extras_require={

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -275,8 +275,6 @@ def main(prog=None):
                                                         "left button, 'a' right, 's' both). Default: arrow keys")
     group.add_argument('--progressive', action='store_true', help='Enable step-by-step rendering of graphical elements')
     group.add_argument('--zoom', help='Display pixel size.', type=int, choices=range(1, 11))
-    group.add_argument('--force-full-ocr', action='store_true',
-                       help='Degrade screen display to enhance OCR capacities for inverted text (only for Stax)')
     group.add_argument('--legacy-ocr', action='store_true',
                        help='Use legacy font maps OCR (only for Nano X & Nano SP). Faster but can have some character detection issues.')
     group.add_argument('--disable-tesseract', action='store_true', help='Disable tesseract OCR: only for stax')
@@ -488,7 +486,7 @@ def main(prog=None):
         args.disable_tesseract = True
 
     display_args = display.DisplayArgs(args.color, args.model, args.ontop, rendering,
-                                       args.keymap, zoom, x, y, args.force_full_ocr, args.legacy_ocr,
+                                       args.keymap, zoom, x, y, args.legacy_ocr,
                                        args.disable_tesseract)
     server_args = display.ServerArgs(apdu, apirun, button, finger, seph, vnc)
     screen = Screen(display_args, server_args)

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -276,7 +276,8 @@ def main(prog=None):
     group.add_argument('--progressive', action='store_true', help='Enable step-by-step rendering of graphical elements')
     group.add_argument('--zoom', help='Display pixel size.', type=int, choices=range(1, 11))
     group.add_argument('--legacy-ocr', action='store_true',
-                       help='Use legacy font maps OCR (only for Nano X & Nano SP). Faster but can have some character detection issues.')
+                       help='Use legacy font maps OCR (only for Nano X & Nano SP).'
+                       'Faster but can have some character detection issues.')
     group.add_argument('--disable-tesseract', action='store_true', help='Disable tesseract OCR: only for stax')
 
     if prog:

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -277,6 +277,8 @@ def main(prog=None):
     group.add_argument('--zoom', help='Display pixel size.', type=int, choices=range(1, 11))
     group.add_argument('--force-full-ocr', action='store_true',
                        help='Degrade screen display to enhance OCR capacities for inverted text (only for Stax)')
+    group.add_argument('--legacy-ocr', action='store_true',
+                       help='Use legacy font maps OCR (only for Nano X & Nano SP). Faster but can have some character detection issues.')
     group.add_argument('--disable-tesseract', action='store_true', help='Disable tesseract OCR: only for stax')
 
     if prog:
@@ -486,7 +488,7 @@ def main(prog=None):
         args.disable_tesseract = True
 
     display_args = display.DisplayArgs(args.color, args.model, args.ontop, rendering,
-                                       args.keymap, zoom, x, y, args.force_full_ocr,
+                                       args.keymap, zoom, x, y, args.force_full_ocr, args.legacy_ocr,
                                        args.disable_tesseract)
     server_args = display.ServerArgs(apdu, apirun, button, finger, seph, vnc)
     screen = Screen(display_args, server_args)

--- a/speculos/mcu/bagl.py
+++ b/speculos/mcu/bagl.py
@@ -66,10 +66,11 @@ DrawState = namedtuple('DrawState', 'x y width height colors bpp xx yy')
 
 
 class Bagl:
-    def __init__(self, m, size):
+    def __init__(self, m, size, legacy_ocr):
         self.m = m
         self.SCREEN_WIDTH, self.SCREEN_HEIGHT = size
         self.draw_state = DrawState(0, 0, 0, 0, [], 0, 0, 0)
+        self.legacy_ocr = legacy_ocr
         self.logger = logging.getLogger("bagl")
 
     def refresh(self) -> bool:

--- a/speculos/mcu/display.py
+++ b/speculos/mcu/display.py
@@ -10,7 +10,7 @@ from .vnc import VNC
 
 Server = Union[ApduServer, FakeButton, FakeFinger, SeProxyHal, VNC]
 
-DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size x y force_full_ocr legacy_ocr, \
+DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size x y legacy_ocr, \
         disable_tesseract")
 ServerArgs = namedtuple("ServerArgs", "apdu apirun button finger seph vnc")
 
@@ -93,7 +93,6 @@ class Display(ABC):
         self.apdu = server.apdu
         self.seph = server.seph
         self.model = display.model
-        self.force_full_ocr = display.force_full_ocr
         self.legacy_ocr = display.legacy_ocr
         self.disable_tesseract = display.disable_tesseract
         self.rendering = display.rendering

--- a/speculos/mcu/display.py
+++ b/speculos/mcu/display.py
@@ -10,7 +10,7 @@ from .vnc import VNC
 
 Server = Union[ApduServer, FakeButton, FakeFinger, SeProxyHal, VNC]
 
-DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size x y force_full_ocr, \
+DisplayArgs = namedtuple("DisplayArgs", "color model ontop rendering keymap pixel_size x y force_full_ocr legacy_ocr, \
         disable_tesseract")
 ServerArgs = namedtuple("ServerArgs", "apdu apirun button finger seph vnc")
 
@@ -94,6 +94,7 @@ class Display(ABC):
         self.seph = server.seph
         self.model = display.model
         self.force_full_ocr = display.force_full_ocr
+        self.legacy_ocr = display.legacy_ocr
         self.disable_tesseract = display.disable_tesseract
         self.rendering = display.rendering
 

--- a/speculos/mcu/headless.py
+++ b/speculos/mcu/headless.py
@@ -17,7 +17,7 @@ class Headless(Display):
         if display.model != "stax":
             self.bagl = bagl.Bagl(self.m, MODELS[self.model].screen_size, display.legacy_ocr)
         else:
-            self.nbgl = nbgl.NBGL(self.m, MODELS[self.model].screen_size, display.force_full_ocr,
+            self.nbgl = nbgl.NBGL(self.m, MODELS[self.model].screen_size,
                                   display.disable_tesseract)
 
     def display_status(self, data):

--- a/speculos/mcu/headless.py
+++ b/speculos/mcu/headless.py
@@ -15,7 +15,7 @@ class Headless(Display):
 
         self.m = HeadlessPaintWidget(self, self.model, server.vnc)
         if display.model != "stax":
-            self.bagl = bagl.Bagl(self.m, MODELS[self.model].screen_size)
+            self.bagl = bagl.Bagl(self.m, MODELS[self.model].screen_size, display.legacy_ocr)
         else:
             self.nbgl = nbgl.NBGL(self.m, MODELS[self.model].screen_size, display.force_full_ocr,
                                   display.disable_tesseract)

--- a/speculos/mcu/nbgl.py
+++ b/speculos/mcu/nbgl.py
@@ -29,11 +29,10 @@ class NBGL:
         if bpp == 4:
             return color * 0x111111
 
-    def __init__(self, m, size, force_full_ocr, disable_tesseract):
+    def __init__(self, m, size, disable_tesseract):
         self.m = m
         # front screen dimension
         self.SCREEN_WIDTH, self.SCREEN_HEIGHT = size
-        self.force_full_ocr = force_full_ocr
         self.disable_tesseract = disable_tesseract
 
     def __assert_area(self, area):
@@ -46,9 +45,6 @@ class NBGL:
 
     def hal_draw_rect(self, data):
         area = nbgl_area_t.parse(data)
-        if self.force_full_ocr:
-            # We need all text shown in black with white background
-            area.color = 3
 
         self.__assert_area(area)
         for x in range(area.x0, area.x0+area.width):
@@ -117,15 +113,6 @@ class NBGL:
         buffer = data[nbgl_area_t.sizeof(): nbgl_area_t.sizeof()+buffer_size]
         transformation = data[nbgl_area_t.sizeof()+buffer_size]
         color_map = data[nbgl_area_t.sizeof()+buffer_size + 1]  # front color in case of BPP4
-
-        if self.force_full_ocr:
-            # Avoid white on black text
-            if (bpp == 4) and (color_map == NbglColor.WHITE) and (area.color == NbglColor.BLACK):
-                area.color = NbglColor.WHITE
-                color_map = NbglColor.BLACK
-            elif bpp != 4 and color_map == 3:
-                area.color = NbglColor.WHITE
-                color_map = 0
 
         if transformation == 0:
             x = area.x0 + area.width - 1

--- a/speculos/mcu/ocr.py
+++ b/speculos/mcu/ocr.py
@@ -2,6 +2,7 @@ from typing import List, Mapping
 from dataclasses import dataclass
 from PIL import Image, ImageOps
 from pytesseract import image_to_data, Output
+from pathlib import Path
 import functools
 import string
 import cv2
@@ -19,6 +20,7 @@ NEW_LINE_THRESHOLD = 10  # pixels
 STAX_BOX_MIN_HEIGHT = 50  # pixels
 STAX_BOX_MIN_WIDTH = 100  # pixels
 # Used for Nano X, Nano SP
+NANO_TESS_MODEL="nano-font-ocr"
 # Image crop (left and right) margin.
 NANO_IMAGE_CROP_MARGIN = 6  # pixels
 # Image upscale factor.
@@ -239,10 +241,10 @@ class OCR:
             image = ImageOps.invert(image)
             image = image.crop((c, 0, w - c, h))
             image = image.resize((w * s, h * s))
-            # image.save(f"flowerbefore{idx}.png")
             image = self._nano_remove_non_text_areas(image)
-            # image.save(f"flower{idx}.png")
-            data = image_to_data(image, output_type=Output.DICT, lang="nano_font")
+            tessdata_dir_config = f"--tessdata-dir {Path(__file__).parent.resolve()}/resources"
+            # Perform OCR using the model trained with https://github.com/LedgerHQ/app-tess-train
+            data = image_to_data(image, output_type=Output.DICT, lang=NANO_TESS_MODEL, config=tessdata_dir_config)
         elif device == "stax":
             image = self._stax_detect_and_invert_box_shapes(image)
             data = image_to_data(image, output_type=Output.DICT)

--- a/speculos/mcu/ocr.py
+++ b/speculos/mcu/ocr.py
@@ -1,7 +1,8 @@
 from typing import List, Mapping
 from dataclasses import dataclass
-from PIL import Image
+from PIL import Image, ImageOps
 from pytesseract import image_to_data, Output
+from enum import Enum
 import functools
 import string
 
@@ -22,6 +23,9 @@ __FONT_MAP = {}
 
 DISPLAY_CHARS = string.ascii_letters + string.digits + string.punctuation
 
+class OCR_Mode(Enum):
+    NORMAL = 1
+    INVERT = 2 # Invert colors of whole picture.
 
 def cache_font(f):
     __font_char_cache = {}
@@ -156,8 +160,10 @@ class OCR:
                 # create a new TextEvent if there are no events yet or if there is a new line
                 self.events.append(TextEvent(char, x, y))
 
-    def analyze_image(self, screen_size: (int, int), data: bytes):
+    def analyze_image(self, screen_size: (int, int), data: bytes, mode: OCR_Mode = OCR_Mode.NORMAL):
         image = Image.frombytes("RGB", screen_size, data)
+        if mode == OCR_Mode.INVERT:
+            image = ImageOps.invert(image)
         data = image_to_data(image, output_type=Output.DICT)
         new_text_has_been_added = False
         for item in range(len(data["text"])):

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -198,7 +198,7 @@ class Screen(Display):
         if display.model != "stax":
             self.bagl = bagl.Bagl(app.m, MODELS[display.model].screen_size)
         else:
-            self.nbgl = nbgl.NBGL(app.m, MODELS[display.model].screen_size, display.force_full_ocr,
+            self.nbgl = nbgl.NBGL(app.m, MODELS[display.model].screen_size,
                                   display.disable_tesseract)
         self.seph = server.seph
 

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -196,7 +196,7 @@ class Screen(Display):
         super().__init__(display, server)
         self._init_notifiers(server)
         if display.model != "stax":
-            self.bagl = bagl.Bagl(app.m, MODELS[display.model].screen_size)
+            self.bagl = bagl.Bagl(app.m, MODELS[display.model].screen_size, display.legacy_ocr)
         else:
             self.nbgl = nbgl.NBGL(app.m, MODELS[display.model].screen_size,
                                   display.disable_tesseract)

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -307,7 +307,7 @@ class SeProxyHal:
                 if not screen.nbgl.disable_tesseract:
                     screen.nbgl.m.update_screenshot()
                     screen_size, image_data = screen.nbgl.m.take_screenshot()
-                    self.ocr.analyze_image(screen_size, image_data)
+                    self.ocr.analyze_image(screen_size, image_data, OCR_Mode.BOX_INVERT)
 
             elif tag == 0x6c:
                 screen.nbgl.hal_draw_line(data)

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -7,7 +7,7 @@ from enum import IntEnum
 from typing import List
 
 from . import usb
-from .ocr import OCR, OCR_Mode
+from .ocr import OCR
 from .readerror import ReadError, WriteError
 from .automation import TextEvent
 
@@ -254,7 +254,7 @@ class SeProxyHal:
                             if not screen.bagl.legacy_ocr:
                                 screen.bagl.m.update_screenshot()
                                 screen_size, image_data = screen.bagl.m.take_screenshot()
-                                self.ocr.analyze_image(screen_size, image_data, OCR_Mode.INVERT)
+                                self.ocr.analyze_image(screen_size, image_data, screen.model)
                             self.events += self.ocr.get_events()
                     elif screen.model == "stax":
                         self.events += self.ocr.get_events()
@@ -307,7 +307,7 @@ class SeProxyHal:
                 if not screen.nbgl.disable_tesseract:
                     screen.nbgl.m.update_screenshot()
                     screen_size, image_data = screen.nbgl.m.take_screenshot()
-                    self.ocr.analyze_image(screen_size, image_data, OCR_Mode.BOX_INVERT)
+                    self.ocr.analyze_image(screen_size, image_data, screen.model)
 
             elif tag == 0x6c:
                 screen.nbgl.hal_draw_line(data)


### PR DESCRIPTION
## New OCR for Nano X, Nano SP
* Uses Tesseract,
* Slower (detection takes ~80ms compared to ~0.05ms), but no detection bugs and no dependancy on font bitmaps. On Ragger batch of 32 tests that previously took ~90s to run, it now takes ~100s.
* Old OCR still available with new `--legacy-ocr` command line argument.

## Improved OCR for Stax
* Detect boxes with black background and invert them for tesseract detection.
* No need for `force-full-ocr` parameter anymore.
* No significant time penalty (contour detection takes ~1.5ms but OCR takes already ~200ms on a Stax snapshot)

Main drawback of this method : can't reliably detect non-words text (like addresses etc...)