### PR TITLE
speculos: Avoid flooding app with tickers and fix button and touch wait delay

### DIFF
--- a/speculos/api/button.py
+++ b/speculos/api/button.py
@@ -1,4 +1,3 @@
-import time
 import jsonschema
 from flask import request
 
@@ -19,13 +18,16 @@ class Button(SephResource):
         button = request.base_url.split("/")[-1]
         buttons = {"left": [1], "right": [2], "both": [1, 2]}
         action = args["action"]
-        actions = {"press": [True], "release": [False], "press-and-release": [True, False]}
         delay = args.get("delay", 0.1)
 
-        for a in actions[action]:
+        if action == "press-and-release":
             for b in buttons[button]:
-                self.seph.handle_button(b, a)
-            if action == "press-and-release":
-                time.sleep(delay)
+                self.seph.handle_button(b, True)
+            self.seph.handle_wait(delay)
+            for b in buttons[button]:
+                self.seph.handle_button(b, False)
+        else:
+            for b in buttons[button]:
+                self.seph.handle_button(b, action == "press")
 
         return {}, 200

--- a/speculos/api/finger.py
+++ b/speculos/api/finger.py
@@ -1,4 +1,3 @@
-import time
 import jsonschema
 from flask import request
 
@@ -17,12 +16,13 @@ class Finger(SephResource):
             return {"error": f"{e}"}, 400
 
         action = args["action"]
-        actions = {"press": [True], "release": [False], "press-and-release": [True, False]}
         delay = args.get("delay", 0.1)
 
-        for a in actions[action]:
-            self.seph.handle_finger(args["x"], args["y"], a)
-            if action == "press-and-release":
-                time.sleep(delay)
+        if action == "press-and-release":
+            self.seph.handle_finger(args["x"], args["y"], True)
+            self.seph.handle_wait(delay)
+            self.seph.handle_finger(args["x"], args["y"], False)
+        else:
+            self.seph.handle_finger(args["x"], args["y"], action == "press")
 
         return {}, 200


### PR DESCRIPTION
This is necessary when OCR takes a lot of time:
- without this, many ticker events will be send during the OCR, which will lead to a timeout for responding on the app side.
- as ticker events might be dropped (if speculos thread is busy), then buttons and finger delay should take it into account.

Note that before this change, buttons and finger delay was also done after release which is not requested and probably not wanted. This is not the case anymore.