### PR TITLE
Add the support for new prototypes of os_endorsement functions

### DIFF
--- a/sdk/bolos_syscalls_unified_sdk.h
+++ b/sdk/bolos_syscalls_unified_sdk.h
@@ -106,10 +106,8 @@
 #define SYSCALL_os_perso_derive_node_with_seed_key_ID_IN              0x080000a6
 #define SYSCALL_os_perso_derive_eip2333_ID_IN                         0x040000a7
 #define SYSCALL_os_endorsement_get_code_hash_ID_IN                    0x01000055
-#define SYSCALL_os_endorsement_get_public_key_ID_IN                   0x02000056
-#define SYSCALL_os_endorsement_get_public_key_new_ID_IN               0x03000056
-#define SYSCALL_os_endorsement_get_public_key_certificate_ID_IN       0x02000057
-#define SYSCALL_os_endorsement_get_public_key_certificate_new_ID_IN   0x03000057
+#define SYSCALL_os_endorsement_get_public_key_ID_IN                   0x03000056
+#define SYSCALL_os_endorsement_get_public_key_certificate_ID_IN       0x03000057
 #define SYSCALL_os_endorsement_key1_get_app_secret_ID_IN              0x01000058
 #define SYSCALL_os_endorsement_key1_sign_data_ID_IN                   0x03000059
 #define SYSCALL_os_endorsement_key2_derive_sign_data_ID_IN            0x0300005a

--- a/sdk/bolos_syscalls_unified_sdk.h
+++ b/sdk/bolos_syscalls_unified_sdk.h
@@ -107,7 +107,9 @@
 #define SYSCALL_os_perso_derive_eip2333_ID_IN                         0x040000a7
 #define SYSCALL_os_endorsement_get_code_hash_ID_IN                    0x01000055
 #define SYSCALL_os_endorsement_get_public_key_ID_IN                   0x02000056
+#define SYSCALL_os_endorsement_get_public_key_new_ID_IN               0x03000056
 #define SYSCALL_os_endorsement_get_public_key_certificate_ID_IN       0x02000057
+#define SYSCALL_os_endorsement_get_public_key_certificate_new_ID_IN   0x03000057
 #define SYSCALL_os_endorsement_key1_get_app_secret_ID_IN              0x01000058
 #define SYSCALL_os_endorsement_key1_sign_data_ID_IN                   0x03000059
 #define SYSCALL_os_endorsement_key2_derive_sign_data_ID_IN            0x0300005a

--- a/src/bolos/endorsement.c
+++ b/src/bolos/endorsement.c
@@ -80,7 +80,9 @@ unsigned long sys_os_endorsement_get_public_key(uint8_t index, uint8_t *buffer)
   return 65;
 }
 
-unsigned int sys_os_endorsement_get_public_key_new(uint8_t index, uint8_t *buffer, uint8_t* length)
+unsigned int sys_os_endorsement_get_public_key_new(uint8_t index,
+                                                   uint8_t *buffer,
+                                                   uint8_t *length)
 {
   *length = sys_os_endorsement_get_public_key(index, buffer);
 
@@ -117,10 +119,8 @@ sys_os_endorsement_get_public_key_certificate(unsigned char index,
   return length;
 }
 
-unsigned int
-sys_os_endorsement_get_public_key_certificate_new(unsigned char index,
-                                              unsigned char *buffer,
-                                              unsigned char *length)
+unsigned int sys_os_endorsement_get_public_key_certificate_new(
+    unsigned char index, unsigned char *buffer, unsigned char *length)
 {
   *length = sys_os_endorsement_get_public_key_certificate(index, buffer);
 

--- a/src/bolos/endorsement.c
+++ b/src/bolos/endorsement.c
@@ -80,6 +80,13 @@ unsigned long sys_os_endorsement_get_public_key(uint8_t index, uint8_t *buffer)
   return 65;
 }
 
+unsigned int sys_os_endorsement_get_public_key_new(uint8_t index, uint8_t *buffer, uint8_t* length)
+{
+  *length = sys_os_endorsement_get_public_key(index, buffer);
+
+  return 0;
+}
+
 unsigned int
 sys_os_endorsement_get_public_key_certificate(unsigned char index,
                                               unsigned char *buffer)
@@ -108,6 +115,16 @@ sys_os_endorsement_get_public_key_certificate(unsigned char index,
   memcpy(buffer, certificate, length);
 
   return length;
+}
+
+unsigned int
+sys_os_endorsement_get_public_key_certificate_new(unsigned char index,
+                                              unsigned char *buffer,
+                                              unsigned char *length)
+{
+  *length = sys_os_endorsement_get_public_key_certificate(index, buffer);
+
+  return 0;
 }
 
 unsigned long sys_os_endorsement_key1_sign_data(uint8_t *data,

--- a/src/bolos/endorsement.h
+++ b/src/bolos/endorsement.h
@@ -1,6 +1,7 @@
 #pragma once
 
 unsigned long sys_os_endorsement_get_public_key(uint8_t index, uint8_t *buffer);
+unsigned int sys_os_endorsement_get_public_key_new(uint8_t index, uint8_t *buffer, uint8_t* length);
 unsigned long sys_os_endorsement_key1_sign_data(uint8_t *data,
                                                 size_t dataLength,
                                                 uint8_t *signature);
@@ -8,3 +9,8 @@ unsigned int sys_os_endorsement_get_code_hash(uint8_t *buffer);
 unsigned int
 sys_os_endorsement_get_public_key_certificate(unsigned char index,
                                               unsigned char *buffer);
+
+unsigned int
+sys_os_endorsement_get_public_key_certificate_new(unsigned char index,
+                                              unsigned char *buffer,
+                                              unsigned char *length);

--- a/src/bolos/endorsement.h
+++ b/src/bolos/endorsement.h
@@ -1,7 +1,9 @@
 #pragma once
 
 unsigned long sys_os_endorsement_get_public_key(uint8_t index, uint8_t *buffer);
-unsigned int sys_os_endorsement_get_public_key_new(uint8_t index, uint8_t *buffer, uint8_t* length);
+unsigned int sys_os_endorsement_get_public_key_new(uint8_t index,
+                                                   uint8_t *buffer,
+                                                   uint8_t *length);
 unsigned long sys_os_endorsement_key1_sign_data(uint8_t *data,
                                                 size_t dataLength,
                                                 uint8_t *signature);
@@ -10,7 +12,5 @@ unsigned int
 sys_os_endorsement_get_public_key_certificate(unsigned char index,
                                               unsigned char *buffer);
 
-unsigned int
-sys_os_endorsement_get_public_key_certificate_new(unsigned char index,
-                                              unsigned char *buffer,
-                                              unsigned char *length);
+unsigned int sys_os_endorsement_get_public_key_certificate_new(
+    unsigned char index, unsigned char *buffer, unsigned char *length);

--- a/src/emulate.h
+++ b/src/emulate.h
@@ -239,6 +239,20 @@ unsigned long sys_os_lib_throw(unsigned int exception);
     break;                                                                     \
   }
 
+#define SYSCALL3i(_name, _fmt, _type0, _arg0, _type1, _arg1, _type2, _arg2,    \
+                  _funcname)                                                   \
+  case SYSCALL_##_name##_ID_IN: {                                              \
+    _type0 _arg0 = (_type0)parameters[0];                                      \
+    _type1 _arg1 = (_type1)parameters[1];                                      \
+    _type2 _arg2 = (_type2)parameters[2];                                      \
+    print_syscall(#_name "" _fmt, (_type0)_arg0, (_type1)_arg1,                \
+                  (_type2)_arg2);                                              \
+    *ret = sys_##_funcname(_arg0, _arg1, _arg2);                               \
+    print_ret(*ret);                                                           \
+    GET_RETID(SYSCALL_##_name##_ID_OUT);                                       \
+    break;                                                                     \
+  }
+
 #define SYSCALL4(_name, _fmt, _type0, _arg0, _type1, _arg1, _type2, _arg2,     \
                  _type3, _arg3)                                                \
   case SYSCALL_##_name##_ID_IN: {                                              \

--- a/src/emulate_unified_sdk.c
+++ b/src/emulate_unified_sdk.c
@@ -705,28 +705,22 @@ int emulate_syscall_endorsement(unsigned long syscall,
   SYSCALL1(os_endorsement_get_code_hash, "(%p)",
            uint8_t *, buffer);
 
-  SYSCALL2(os_endorsement_get_public_key, "(%d, %p)",
-           uint8_t,   index,
-           uint8_t *, buffer);
-
-  SYSCALL2(os_endorsement_get_public_key_certificate, "(%d, %p)",
-           unsigned char,   index,
-           unsigned char *, buffer);
-
   SYSCALL3(os_endorsement_key1_sign_data, "(%p, %u, %p)",
            uint8_t *, data,
            size_t,    dataLength,
            uint8_t *, signature);
 
-  SYSCALL3(os_endorsement_get_public_key_new, "(%d, %p, %p)",
+  SYSCALL3i(os_endorsement_get_public_key, "(%d, %p, %p)",
            uint8_t,   index,
            uint8_t *, buffer,
-           uint8_t *, length);
+           uint8_t *, length,
+           os_endorsement_get_public_key_new);
 
-  SYSCALL3(os_endorsement_get_public_key_certificate_new, "(%d, %p, %p)",
+  SYSCALL3i(os_endorsement_get_public_key_certificate, "(%d, %p, %p)",
            unsigned char,   index,
            unsigned char *, buffer,
-           unsigned char *, length)
+           unsigned char *, length,
+           os_endorsement_get_public_key_certificate_new);
 
   /* clang-format on */
   default:

--- a/src/emulate_unified_sdk.c
+++ b/src/emulate_unified_sdk.c
@@ -718,6 +718,16 @@ int emulate_syscall_endorsement(unsigned long syscall,
            size_t,    dataLength,
            uint8_t *, signature);
 
+  SYSCALL3(os_endorsement_get_public_key_new, "(%d, %p, %p)",
+           uint8_t,   index,
+           uint8_t *, buffer,
+           uint8_t *, length);
+
+  SYSCALL3(os_endorsement_get_public_key_certificate_new, "(%d, %p, %p)",
+           unsigned char,   index,
+           unsigned char *, buffer,
+           unsigned char *, length)
+
   /* clang-format on */
   default:
     return SYSCALL_NOT_HANDLED;

--- a/tests/syscalls/test_endorsement.c
+++ b/tests/syscalls/test_endorsement.c
@@ -17,8 +17,11 @@
 #define os_endorsement_get_code_hash sys_os_endorsement_get_code_hash
 #define os_endorsement_get_public_key_certificate                              \
   sys_os_endorsement_get_public_key_certificate
-#define os_endorsement_get_public_key sys_os_endorsement_get_public_key
-#define os_endorsement_key1_sign_data sys_os_endorsement_key1_sign_data
+#define os_endorsement_get_public_key_certificate_new                          \
+  sys_os_endorsement_get_public_key_certificate_new
+#define os_endorsement_get_public_key     sys_os_endorsement_get_public_key
+#define os_endorsement_get_public_key_new sys_os_endorsement_get_public_key_new
+#define os_endorsement_key1_sign_data     sys_os_endorsement_key1_sign_data
 
 void test_endorsement(void **state __attribute__((unused)))
 {
@@ -87,8 +90,78 @@ void test_endorsement(void **state __attribute__((unused)))
                    1);
 };
 
+void test_endorsement_new(void **state __attribute__((unused)))
+{
+  uint8_t raw_endorsement_pubkey[65] = { 0 };
+  uint8_t endorsement_sig[80] = { 0 };
+  uint8_t endorsement_key1_sig[80] = { 0 };
+  size_t endorsement_key1_sig_len;
+  uint8_t pubkey_len = 0, endorsement_sig_len = 0;
+  cx_ecfp_public_key_t endorsement_pubkey, blue_owner_endorsement_pubkey;
+  cx_sha256_t sha256;
+  uint8_t certif_prefix = 0xFE;
+  uint8_t hash[32];
+  uint8_t code_hash[32];
+  uint8_t nonce[4] = { 0x12, 0x34, 0x56, 0x78 };
+
+  // test key
+  uint8_t BLUE_OWNER_PUBLIC_KEY[] = {
+    0x04, 0x41, 0x14, 0xd1, 0x6a, 0xec, 0xed, 0xa8, 0xd7, 0x81, 0x31,
+    0x1b, 0xd3, 0x4f, 0xd5, 0x7a, 0x44, 0xac, 0xfc, 0xbc, 0xf3, 0x57,
+    0xf0, 0x67, 0x88, 0x46, 0x48, 0x07, 0x32, 0x52, 0x69, 0x9c, 0xbd,
+    0x46, 0xf6, 0x41, 0xc1, 0x75, 0x54, 0xed, 0x65, 0x3e, 0x6a, 0x42,
+    0x7f, 0x4a, 0xea, 0xfa, 0xf7, 0x4e, 0x32, 0x18, 0xe5, 0xdd, 0x0c,
+    0x04, 0x20, 0xb6, 0xc8, 0xcf, 0x60, 0x5a, 0x04, 0x96, 0x4e
+  };
+
+  assert_int_equal(0, os_endorsement_get_public_key_new(
+                          1, raw_endorsement_pubkey, &pubkey_len));
+  assert_int_equal(pubkey_len, 65);
+  assert_int_equal(raw_endorsement_pubkey[0], 0x04);
+
+  assert_int_equal(cx_ecfp_init_public_key(CX_CURVE_256K1,
+                                           raw_endorsement_pubkey, pubkey_len,
+                                           &endorsement_pubkey),
+                   pubkey_len);
+  assert_int_equal(cx_ecfp_init_public_key(CX_CURVE_256K1,
+                                           BLUE_OWNER_PUBLIC_KEY,
+                                           sizeof(BLUE_OWNER_PUBLIC_KEY),
+                                           &blue_owner_endorsement_pubkey),
+                   sizeof(BLUE_OWNER_PUBLIC_KEY));
+
+  assert_int_equal(cx_sha256_init(&sha256), CX_SHA256);
+  assert_int_equal(cx_hash(&sha256.header, 0, &certif_prefix, 1, NULL, 0), 0);
+  assert_int_equal(cx_hash(&sha256.header, CX_LAST, raw_endorsement_pubkey,
+                           sizeof(raw_endorsement_pubkey), hash, 32),
+                   32);
+
+  assert_int_equal(0, os_endorsement_get_public_key_certificate_new(
+                          1, endorsement_sig, &endorsement_sig_len));
+  assert_int_equal(cx_ecdsa_verify(&blue_owner_endorsement_pubkey, CX_LAST,
+                                   CX_SHA256, hash, sizeof(hash),
+                                   endorsement_sig, endorsement_sig_len),
+                   1);
+
+  assert_int_equal(os_endorsement_get_code_hash(code_hash), 32);
+
+  assert_int_equal(cx_sha256_init(&sha256), CX_SHA256);
+  assert_int_equal(cx_hash(&sha256.header, 0, nonce, sizeof(nonce), NULL, 0),
+                   0);
+  assert_int_equal(
+      cx_hash(&sha256.header, CX_LAST, code_hash, sizeof(code_hash), hash, 32),
+      32);
+
+  endorsement_key1_sig_len =
+      os_endorsement_key1_sign_data(nonce, sizeof(nonce), endorsement_key1_sig);
+  assert_int_equal(cx_ecdsa_verify(&endorsement_pubkey, CX_LAST, CX_SHA256,
+                                   hash, sizeof(hash), endorsement_key1_sig,
+                                   endorsement_key1_sig_len),
+                   1);
+};
+
 int main(void)
 {
-  const struct CMUnitTest tests[] = { cmocka_unit_test(test_endorsement) };
+  const struct CMUnitTest tests[] = { cmocka_unit_test(test_endorsement),
+                                      cmocka_unit_test(test_endorsement_new) };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Add support for new prototypes of `os_endorsement_get_public_key` and `os_endorsement_get_public_key_certificate`