### PR TITLE
Add Stax mentions in the documentation and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![screenshot btc nano s](docs/screenshot-api-nanos-btc.png)
 
-The goal of this project is to emulate Ledger Nano S, Nano X and Blue apps on
+The goal of this project is to emulate Ledger Nano S/S+, Nano X, Blue and Stax apps on
 standard desktop computers, without any hardware device. More information can
 be found here in the
 [documentation website](https://ledgerhq.github.io/speculos) (or in the

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -12,12 +12,13 @@ After having [installed the requirements and built](../installation/build.md) sp
 
 The docker image can also be used directly, as detailed in the specific [docker documentation page](docker.md).
 
-The Nano S is the default model; the Nano X and Blue can be specified on the
-command-line:
+With applications built by recent SDKs, Speculos can automatically detect the targeted device. Otherwise, the Nano S is the default; the Nano X, Nano S+, Stax and Blue can be specified on the command line:
 
 ```shell
 ./speculos.py --model nanox apps/nanox#btc#2.0.2#1c8db8da.elf
+./speculos.py --model nanosp apps/nanosp#btc#1.0.3#17bf7619.elf
 ./speculos.py --model blue --sdk 1.5 apps/blue#btc#1.5#00000000.elf
+./speculos.py --model stax apps/btc.elf.elf
 ```
 
 The last SDK version is automatically selected. However, a specific version
@@ -32,9 +33,9 @@ against the SDK `1.5` on the Nano S:
 Supported SDK values for each device are defined in [src/sdk.h](https://github.com/LedgerHQ/speculos/blob/master/src/sdk.h).
 You main choose the SDK using `-k`/`--sdk` argument:
 
-|     | Nano S             | Nano X          | Blue            |
-|-----|--------------------|-----------------|-----------------|
-| SDK | 1.5, 1.6, 2.0, 2.1 | 1.2, 2.0, 2.0.2 | 1.5, blue-2.2.5 |
+|     | Nano S             | Nano S+    | Nano X          | Blue            |
+|-----|--------------------|------------|-----------------|-----------------|
+| SDK | 1.5, 1.6, 2.0, 2.1 | 1.0, 1.0.3 | 1.2, 2.0, 2.0.2 | 1.5, blue-2.2.5 |
 
 For more options, pass the `-h` or `--help` flag.
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version="0.1.0",
     url="https://github.com/LedgerHQ/speculos",
     python_requires=">=3.6.0",
-    description="Ledger Blue and Nano S/X application emulator",
+    description="Ledger Blue, Stax and Nano S/S+/X application emulator",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
Not a big change, but I was mistakenly convinced that Speculos didn't support Ledger Stax given the description of the repo and the fact that it wasn't mentioned in the doc.