### PR TITLE
Deployment fix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -134,7 +134,6 @@ jobs:
           echo >&2 "Error: dist/ directory already exists and this is unexpected. Refusing to build new packages."
           exit 1
         fi
-        sed -i 's;docs/screenshot-api-nanos-btc\.png;https://raw.githubusercontent.com/LedgerHQ/speculos/develop/docs/screenshot-api-nanos-btc.png;' README.md
         python3 -m venv venv-build
         ./venv-build/bin/pip install --upgrade pip build twine
         ./venv-build/bin/python -m build

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/LedgerHQ/speculos/branch/master/graph/badge.svg)](https://codecov.io/gh/LedgerHQ/speculos)
 [![lgtm](https://img.shields.io/lgtm/alerts/g/LedgerHQ/speculos.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/LedgerHQ/speculos/alerts/)
 
-![screenshot btc nano s](docs/screenshot-api-nanos-btc.png)
+![screenshot btc nano s](https://raw.githubusercontent.com/LedgerHQ/speculos/master/docs/screenshot-api-nanos-btc.png)
 
 The goal of this project is to emulate Ledger Nano S/S+, Nano X, Blue and Stax apps on
 standard desktop computers, without any hardware device. More information can


### PR DESCRIPTION
Image URL in README is now hardcoded.

This avoids the need to `sed` before packaging Speculos in the CI. This feature was generating 'unclean' repository which resulted `setuptools_scm` to generate `<a>.<b>.<c+1>.dev0` versions instead of `<a>.<b>.<c>`.

The issue will be that now, on unmerged branches, the README will refer to this URL pointing to the GitHub pages, which could be out-of-date if changed.
However as a new deployment is performed as soon as the branch is merged on `master`, this is not a very potent problem.