### PR TITLE
Scarce screenshot publish

### DIFF
--- a/speculos/api/events.py
+++ b/speculos/api/events.py
@@ -31,13 +31,18 @@ class EventsBroadcaster:
         self.logger.debug("events: client exited")
         self.clients.remove(client)
 
+    def clear_events(self):
+        self.logger.debug("Clearing events")
+        self.screen_content = []
+
     def broadcast(self, event: TextEvent):
-        self.logger.debug(f"events: broadcasting {asdict(event)} to ({len(self.clients)}) client(s)")
         if self.screen_content:
             # Reset screen content if new event is not below the last text line of
             # current screen. Event Y coordinate starts at the top of the screen.
             if event.y <= self.screen_content[-1].y + MIN_LINES_HEIGHT_DISTANCE:
-                self.screen_content = []
+                self.clear_events()
+
+        self.logger.debug("events: broadcasting %s to %d client(s)", asdict(event), len(self.clients))
         self.screen_content.append(event)
         self.events.append(event)
         for client in self.clients:

--- a/speculos/api/screenshot.py
+++ b/speculos/api/screenshot.py
@@ -1,5 +1,3 @@
-import io
-from PIL import Image
 from flask import Response
 
 from .restful import ScreenResource
@@ -7,10 +5,7 @@ from .restful import ScreenResource
 
 class Screenshot(ScreenResource):
     def get(self):
-        screen_size, data = self.screen.m.take_screenshot()
-        image = Image.frombytes("RGB", screen_size, data)
-        iobytes = io.BytesIO()
-        image.save(iobytes, format="PNG")
-        response = Response(iobytes.getvalue(), mimetype="image/png")
+        iobytes_value = self.screen.m.take_published_screenshot()
+        response = Response(iobytes_value, mimetype="image/png")
         response.headers.add("Cache-control", "no-cache,no-store")
         return response

--- a/speculos/api/screenshot.py
+++ b/speculos/api/screenshot.py
@@ -5,7 +5,7 @@ from .restful import ScreenResource
 
 class Screenshot(ScreenResource):
     def get(self):
-        iobytes_value = self.screen.m.take_published_screenshot()
+        iobytes_value = self.screen.m.get_public_screenshot()
         response = Response(iobytes_value, mimetype="image/png")
         response.headers.add("Cache-control", "no-cache,no-store")
         return response

--- a/speculos/mcu/display.py
+++ b/speculos/mcu/display.py
@@ -98,12 +98,22 @@ class FrameBuffer(ABC):
         self.screenshot.update(self.pixels)
 
     def take_screenshot(self):
-        return self.screenshot.get_image()
+        self.current_screen_size, self.current_data = self.screenshot.get_image()
+        return self.current_screen_size, self.current_data
+
+    @property
+    def published_screenshot_value(self):
+        # Lazy calculation of the published screenshot, as it is a costly operation
+        # and not necessary if no one tries to read the value
+        if self.recreate_iobytes:
+            self.recreate_iobytes = False
+            self._published_screenshot_value = _screenshot_to_iobytes_value(self.current_screen_size, self.current_data)
+
+        return self._published_screenshot_value
 
     def publish_screenshot(self):
         if self.model == "stax":
-            screen_size, data = self.take_screenshot()
-            self.published_screenshot_value = _screenshot_to_iobytes_value(screen_size, data)
+            self.recreate_iobytes = True
         else:
             # Never called
             pass

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -67,6 +67,12 @@ class PaintWidget(QWidget):
     def update_screenshot(self):
         return self.fb.screenshot_update_pixels()
 
+    def publish_screenshot(self):
+        return self.fb.publish_screenshot()
+
+    def take_published_screenshot(self):
+        return self.fb.take_published_screenshot()
+
 
 class App(QMainWindow):
     def __init__(self, qt_app: QApplication, display: DisplayArgs, server: ServerArgs) -> None:

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -67,11 +67,11 @@ class PaintWidget(QWidget):
     def update_screenshot(self):
         return self.fb.screenshot_update_pixels()
 
-    def publish_screenshot(self):
-        return self.fb.publish_screenshot()
+    def update_public_screenshot(self):
+        return self.fb.update_public_screenshot()
 
-    def take_published_screenshot(self):
-        return self.fb.take_published_screenshot()
+    def get_public_screenshot(self):
+        return self.fb.get_public_screenshot()
 
 
 class App(QMainWindow):

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -302,7 +302,7 @@ class SeProxyHal:
                             self.ocr.analyze_image(screen_size, image_data)
 
                             # Publish the new screenshot, we'll upload its associated events shortly
-                            screen.nbgl.m.publish_screenshot()
+                            screen.nbgl.m.update_public_screenshot()
 
                             # OCR is finished, resume time
                             self.time_ticker_thread.resume()

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -189,6 +189,7 @@ class SeProxyHal:
         self.automation = automation
         self.automation_server = automation_server
         self.events: List[TextEvent] = []
+        self.refreshed = False
 
         self.status_event = threading.Event()
         self.packet_thread = PacketDaemon(self.s, self.status_event)
@@ -288,6 +289,24 @@ class SeProxyHal:
 
             if tag == SephTag.GENERAL_STATUS:
                 if int.from_bytes(data[:2], 'big') == SephTag.GENERAL_STATUS_LAST_COMMAND:
+                    if self.refreshed:
+                        self.refreshed = False
+
+                        if not screen.nbgl.disable_tesseract:
+                            # Pause flow of time while the OCR is running
+                            self.time_ticker_thread.pause()
+
+                            # Run the OCR
+                            screen.nbgl.m.update_screenshot()
+                            screen_size, image_data = screen.nbgl.m.take_screenshot()
+                            self.ocr.analyze_image(screen_size, image_data)
+
+                            # OCR is finished, resume time
+                            self.time_ticker_thread.resume()
+
+                            # Publish the new screenshot, we'll upload its associated events shortly
+                            screen.nbgl.m.publish_screenshot()
+
                     if screen.model != "stax" and screen.screen_update():
                         if screen.model in ["nanox", "nanosp"]:
                             self.events += self.ocr.get_events()
@@ -341,14 +360,10 @@ class SeProxyHal:
                 screen.nbgl.hal_draw_rect(data)
             elif tag == 0x6b:
                 screen.nbgl.hal_refresh(data)
-
-                if not screen.nbgl.disable_tesseract:
-                    # Pause flow of time while the OCR is running
-                    self.time_ticker_thread.pause()
-                    screen.nbgl.m.update_screenshot()
-                    screen_size, image_data = screen.nbgl.m.take_screenshot()
-                    self.ocr.analyze_image(screen_size, image_data)
-                    self.time_ticker_thread.resume()
+                # Stax only
+                # We have refreshed the screen, remember it for the next time we have SephTag.GENERAL_STATUS
+                # then we'll perform a new OCR and make public the resulting screenshot / OCR analysis
+                self.refreshed = True
 
             elif tag == 0x6c:
                 screen.nbgl.hal_draw_line(data)

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -301,11 +301,11 @@ class SeProxyHal:
                             screen_size, image_data = screen.nbgl.m.take_screenshot()
                             self.ocr.analyze_image(screen_size, image_data)
 
-                            # OCR is finished, resume time
-                            self.time_ticker_thread.resume()
-
                             # Publish the new screenshot, we'll upload its associated events shortly
                             screen.nbgl.m.publish_screenshot()
+
+                            # OCR is finished, resume time
+                            self.time_ticker_thread.resume()
 
                     if screen.model != "stax" and screen.screen_update():
                         if screen.model in ["nanox", "nanosp"]:


### PR DESCRIPTION
Only publish screenshot content when the OCR is finished on Stax
Rework the take_screenshot to avoid recreating the image at every REST api refresh