### PR TITLE
Keep legacy behaviour

### DIFF
--- a/tests/syscalls/test_mpi_rng.c
+++ b/tests/syscalls/test_mpi_rng.c
@@ -19,8 +19,6 @@ void test_mpi_rng(void **state __attribute__((unused)))
   cx_mpi_t *r, *n;
   int ret;
   cx_err_t error;
-  uint32_t i, j, rnd, value;
-  uint8_t buffer[64];
 
   // Those tests will check that cx_mpi_rng is working as expected:
   // cx_mpi_rng(r,n) => Generate a random value r in the range 0 < r < n.


### PR DESCRIPTION
The previous OCR fix broke some ci/tests made with API_LEVEL_1 built apps.

This PR make the OCR behave _almost_ like legacy one when not using loaded JSON fonts.
(almost because there are still w & h fields which was added to TextEvent fields)