### PR TITLE
fix: do not parse fonts if symbol not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - 2023-09-28
+
+### Fixed
+- OCR: Prevent null dereference when expected font is not in ELF file
+
 ## [0.3.0] - 2023-09-11
 
 ### Added

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -115,6 +115,8 @@ def get_elf_infos(app_path):
             fonts_addr = bagl_fonts_symbol[0]['st_value']
             fonts_size = bagl_fonts_symbol[0]['st_size']
             logger.info(f"Found C_bagl_fonts at 0x{fonts_addr:X} ({fonts_size} bytes)\n")
+        else:
+            logger.info("Disabling OCR.")
 
         supp_ram = elf.get_section_by_name('.rfbss')
         ram_addr, ram_size = (supp_ram['sh_addr'], supp_ram['sh_size']) if supp_ram is not None else (0, 0)

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -541,8 +541,10 @@ static int run_app(char *name, unsigned long *parameters)
   app = get_current_app();
 
   // Parse fonts and build bitmap -> character table
-  parse_fonts(memory.code, app->elf.text_load_addr, app->elf.fonts_addr,
-              app->elf.fonts_size);
+  if ((app->elf.fonts_addr != 0) || (hw_model == MODEL_STAX)) {
+    parse_fonts(memory.code, app->elf.text_load_addr, app->elf.fonts_addr,
+                app->elf.fonts_size);
+  }
 
   /* thumb mode */
   f = (void *)((unsigned long)p | 1);


### PR DESCRIPTION
There's a null dereference occuring in `speculos` itself when passing in a *valid* application that does not contain the `C_bagl_fonts` symbol. This PR removes the offending call to `parse_fonts` if this symbol was not found.