### PR TITLE
[B2CA-1417] The Speculos API is not properly stopped when Speculos quits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2023-09-28
+
+### Fixed
+- API: the API thread is asked to stop when Speculos exits
 
 ## [0.3.1] - 2023-09-28
 

--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -30,6 +30,7 @@ class ApiRunner(IODevice):
         self._notify_exit: socket.socket
         self.sock, self._notify_exit = socket.socketpair()
         self.api_port: int = api_port
+        self._api_thread: threading.Thread
 
     @property
     def file(self):
@@ -55,8 +56,11 @@ class ApiRunner(IODevice):
                             automation_server: BroadcastInterface) -> None:
         wrapper = ApiWrapper(screen_, seph_, automation_server)
         self._app = wrapper.app
-        api_thread = threading.Thread(target=self._run, name="API-server", daemon=True)
-        api_thread.start()
+        self._api_thread = threading.Thread(target=self._run, name="API-server", daemon=True)
+        self._api_thread.start()
+
+    def stop(self):
+        self._api_thread.join(10)
 
 
 class ApiWrapper:

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -520,6 +520,9 @@ def main(prog=None) -> int:
 
     screen_notifier.run()
 
+    if apirun is not None:
+        apirun.stop()
+
     s2.close()
     _, status = os.waitpid(qemu_pid, 0)
     qemu_exit_status = os.WEXITSTATUS(status)


### PR DESCRIPTION
This leads to `DisplayNotifier` implementation-specific behaviors when the application exists - and the `SeProxyHal(IODevice)`  throws a `ReadError` (I guess it's also true for others `IODevice`).

I added a 10s timeout to avoid neverending `.join()` call.