### PR TITLE
speculos: Fasten graphics handling

### DIFF
--- a/speculos/mcu/headless.py
+++ b/speculos/mcu/headless.py
@@ -53,15 +53,16 @@ class HeadlessPaintWidget(FrameBuffer):
                _1: Optional[int] = None,
                _2: Optional[int] = None,
                _3: Optional[int] = None) -> bool:
-        if self.pixels:
+        if self.pixels or self.draw_default_color:
             self._redraw()
             self.pixels = {}
+            self.draw_default_color = False
             return True
         return False
 
     def _redraw(self) -> None:
         if self.vnc:
-            self.vnc.redraw(self.pixels)
+            self.vnc.redraw(self.pixels, self.default_color)
         self.update_screenshot()
 
 

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -30,7 +30,7 @@ class PaintWidget(FrameBuffer, QWidget):
         self.vnc = vnc
 
     def paintEvent(self, event: QEvent):
-        if self.pixels:
+        if self.pixels or self.draw_default_color:
             pixmap = QPixmap(self.size() / self.pixel_size)
             pixmap.fill(Qt.white)
             painter = QPainter(pixmap)
@@ -38,6 +38,7 @@ class PaintWidget(FrameBuffer, QWidget):
             self._redraw(painter)
             self.mPixmap = pixmap
             self.pixels = {}
+            self.draw_default_color = False
 
         qp = QPainter(self)
         copied_pixmap = self.mPixmap
@@ -60,12 +61,15 @@ class PaintWidget(FrameBuffer, QWidget):
         return self.pixels != {}
 
     def _redraw(self, qp):
+        if self.draw_default_color:
+            qp.fillRect(0, 0, self._width, self._height, QColor.fromRgb(self.default_color))
+
         for (x, y), color in self.pixels.items():
             qp.setPen(QColor.fromRgb(color))
             qp.drawPoint(x, y)
 
         if self.vnc is not None:
-            self.vnc.redraw(self.pixels)
+            self.vnc.redraw(self.pixels, self.default_color)
 
         self.update_screenshot()
 

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -322,11 +322,8 @@ class SeProxyHal(IODevice):
                 if self.refreshed:
                     self.refreshed = False
 
-                    # Run the OCR
+                    # Update the screenshot, we'll upload its associated events shortly
                     screen.display.gl.update_screenshot()
-                    screen.display.gl.take_screenshot()
-
-                    # Publish the new screenshot, we'll upload its associated events shortly
                     screen.display.gl.update_public_screenshot()
 
                 if screen.display.model != "stax" and screen.display.screen_update():
@@ -423,7 +420,7 @@ class SeProxyHal(IODevice):
             screen.display.gl.refresh(data)
             # Stax only
             # We have refreshed the screen, remember it for the next time we have SephTag.GENERAL_STATUS
-            # then we'll perform a new OCR and make public the resulting screenshot / OCR analysis
+            # then we'll perform a screen update and make public the resulting screenshot
             self.refreshed = True
 
         elif tag == SephTag.NBGL_DRAW_LINE:


### PR DESCRIPTION
This changes allow to reduce app-boilerplate stax tests run time from 50s to 18s on my setup.
Note that this could be further reduced to 10s if using ragger configuration BACKEND_SCOPE="session".