### PR TITLE
Add suppport for .nvm_data section loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2024-03-25
+
+### Fixed
+- Support `.nvm_data` section loading to avoid crashes in rust apps using persistent storage
+
+
 ## [0.7.1] - 2-24-02-26
 
 ### Fixed

--- a/speculos/main.py
+++ b/speculos/main.py
@@ -69,6 +69,7 @@ def get_elf_ledger_metadata(app_path):
                         metadata[section_name] = "nanosp"
     return metadata
 
+
 def get_segment_from_section(elf, section):
     if section is None:
         return None
@@ -77,6 +78,7 @@ def get_segment_from_section(elf, section):
             return seg
     return None
 
+
 def get_elf_infos(app_path):
     with open(app_path, 'rb') as fp:
         elf = ELFFile(fp)
@@ -84,11 +86,11 @@ def get_elf_infos(app_path):
         text_seg = get_segment_from_section(elf, text)
         if text_seg is None:
             raise RuntimeError("No program header with text section!")
-        
+
         nvm = elf.get_section_by_name('.nvm_data')
         nvm_seg = get_segment_from_section(elf, nvm)
-        nvm_size = nvm_seg['p_filesz']  if nvm_seg is not None else 0
-        
+        nvm_size = nvm_seg['p_filesz'] if nvm_seg is not None else 0
+
         symtab = elf.get_section_by_name('.symtab')
         bss = elf.get_section_by_name('.bss')
         sh_offset = text_seg['p_offset']


### PR DESCRIPTION
In rust apps, an additional section named `.nvm_data` is created in the provided ELF. This section represents the NVM storage state which is not null by default.  
When it's not loaded the rust code panics because it can't find any "valid storage" (https://github.com/LedgerHQ/ledger-device-rust-sdk/blob/610a73b500730b28c0b8c1b556e089a6b102d7c6/ledger_device_sdk/src/nvm.rs#L217-L225).

This PR adds a quick fix to load this section in memory if it exists. What should really be done is loading segments instead of sections (which are used for linking) but there are still things I do not understand at the moment. We could also load the ihex file but this would require to change the way we're running speculos in every project.  

To test this PR, you can use the [Password Manager Rust App](https://github.com/LedgerHQ/rust-app-password-manager/) and try to store a new password with the app running in speculos.