### PR TITLE
[add] Swipe capability on API + SpeculosClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.7] - 2024-??-??
+## [0.9.0] - 2024-??-??
+
+### Added
+
+- Finger swipe capabilities (this feature is currently only available on Flex, using the capability
+  will have no effect on other devices)
 
 ### Fixed
 

--- a/speculos/api/finger.py
+++ b/speculos/api/finger.py
@@ -18,11 +18,13 @@ class Finger(SephResource):
         action = args["action"]
         delay = args.get("delay", 0.1)
 
+        x1, y1 = args["x"], args["y"]
         if action == "press-and-release":
-            self.seph.handle_finger(args["x"], args["y"], True)
+            self.seph.handle_finger(x1, y1, True)
             self.seph.handle_wait(delay)
-            self.seph.handle_finger(args["x"], args["y"], False)
+            x2, y2 = args.get("x2", x1), args.get("y2", y1)
+            self.seph.handle_finger(x2, y2, False)
         else:
-            self.seph.handle_finger(args["x"], args["y"], action == "press")
+            self.seph.handle_finger(x1, y1, action == "press")
 
         return {}, 200

--- a/speculos/api/resources/finger.schema
+++ b/speculos/api/resources/finger.schema
@@ -5,6 +5,8 @@
     "properties": {
         "x": { "type": "integer", "minimum": 0 },
         "y": { "type": "integer", "minimum": 0 },
+        "x2": { "type": "integer", "minimum": 0 },
+        "y2": { "type": "integer", "minimum": 0 },
         "action": { "enum": [ "press", "release", "press-and-release" ] },
         "delay": { "type": "number" }
     },

--- a/speculos/client.py
+++ b/speculos/client.py
@@ -126,8 +126,29 @@ class Api:
         with self.session.post(f"{self.api_url}/button/{button}", json=data) as response:
             check_status_code(response, f"/button/{button}")
 
-    def finger_touch(self, x: int, y: int, delay: float = 0.5) -> None:
+    def finger_touch(self,
+                     x: int, y: int,
+                     x2: Optional[int] = None, y2: Optional[int] = None,
+                     delay: float = 0.5) -> None:
         data = {"action": "press-and-release", "x": x, "y": y, "delay": delay}
+        if x2 is not None:
+            data["x2"] = x2
+        if y2 is not None:
+            data["y2"] = y2
+        with self.session.post(f"{self.api_url}/finger", json=data) as response:
+            check_status_code(response, "/finger")
+
+    def finger_swipe(self, x: int, y: int, direction: str, delay: float = 0.5) -> None:
+        x2, y2 = x, y
+        if direction == "up":
+            y2 -= 10
+        elif direction == "down":
+            y2 += 10
+        elif direction == "left":
+            x2 -= 10
+        elif direction == "right":
+            x2 += 10
+        data = {"action": "press-and-release", "x": x, "y": y, "x2": x2, "y2": y2, "delay": delay}
         with self.session.post(f"{self.api_url}/finger", json=data) as response:
             check_status_code(response, "/finger")
 

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -173,8 +173,6 @@ class App(QMainWindow):
         self.mouse_offset = event.pos()
         x, y = self._get_x_y()
         if x >= 0 and x < self._width and y >= 0 and y < self._height:
-            # Send a press to update the last pressed x,y to the app
-            self.seph.handle_finger(x, y, True)
             # Send the release
             self.seph.handle_finger(x, y, False)
         QApplication.restoreOverrideCursor()


### PR DESCRIPTION
- In the API, the finger route can now receive `x2` and `y2` in addition to the required `x` and `y` position.
  When they exists, `x2` and `y2` will be used as the **second** coordinates when the action is "press-and-release". They will be ignored in other cases.
- In the `SpeculosClient`, added a `finger_swipe` method in addition to the `finger_touch`. This new method takes the classic `x` and `y` but also a direction in [`up`, `down`, `right`, `left`] which automatically adds `x2` and `y2` to the API call.

**Pros**
- Higher level `swipe` method, handier than manually filling the `x2`, `y2`

**Cons**
- As is, the API does not propose direct control on `x2` / `y2` as the finger route allows (maybe adding optional `x2`, `y2` on `finger_touch` ? [EDIT] Added this, so that the client has all capabilities)
- `x2` and `y2` overflow / underflow is not checked currently. A swipe left with `x = 0` will do `x2 = -10`.
  I thought it was too much code to add for an error which is easy to detect (the raised error is quite clear) + currently `x` and `y` or not checked either (they just need to be > 0 but 80000 would be valid).

Thoughts?