### PR TITLE
Remove the vertical alignment assertion on multiples of 4 on Stax

### DIFF
--- a/speculos/mcu/nbgl.py
+++ b/speculos/mcu/nbgl.py
@@ -55,8 +55,6 @@ class NBGL(GraphicLibrary):
         self.logger = logging.getLogger("NBGL")
 
     def __assert_area(self, area) -> None:
-        if self.model == "stax" and (area.y0 % 4 or area.height % 4):
-            raise AssertionError("X(%d) or height(%d) not 4 aligned " % (area.y0, area.height))
         if area.x0 > self.SCREEN_WIDTH or (area.x0+area.width) > self.SCREEN_WIDTH:
             raise AssertionError("left edge (%d) or right edge (%d) out of screen" % (area.x0, (area.x0 + area.width)))
         if area.y0 > self.SCREEN_HEIGHT or (area.y0+area.height) > self.SCREEN_HEIGHT:


### PR DESCRIPTION
The goal of this PR is to remove the vertical alignment assertion on multiples of 4 on Stax, because this constraint doesn't exist anymore on real Stax.