### PR TITLE
Fix wrong display of some image files when BPP is not properly set in area

### DIFF
--- a/src/bolos/nbgl.c
+++ b/src/bolos/nbgl.c
@@ -118,6 +118,10 @@ unsigned long sys_nbgl_front_draw_img_file(nbgl_area_t *area, uint8_t *buffer,
   }
   size_t len = sizeof(nbgl_area_t) + 1;
   size_t buffer_len = 0;
+
+  // force area bpp with the value from "file" to avoid some issues
+  area->bpp = (buffer[4] >> 4) & 0xF;
+
   switch (compressed) {
   case 0: // no compression
     buffer_len = (area->width * area->height * (area->bpp + 1)) / 8;


### PR DESCRIPTION
The goal of this PR is to fix potential inconsistency between the number of BPP set in the area and the number of BPP set in image "file" header. The Header is supposed to be the good one so the one in the area must be overriden.