### PR TITLE
Enable support for secp521r1

### DIFF
--- a/src/bolos/cx_ec_domain.c
+++ b/src/bolos/cx_ec_domain.c
@@ -1539,11 +1539,9 @@ int cx_nid_from_curve(cx_curve_t curve)
   case CX_CURVE_BLS12_381_G1:
     nid = NID_undef;
     break;
-#if 0
   case CX_CURVE_SECP521R1:
     nid = NID_secp521r1;
     break;
-#endif
   default:
     nid = -1;
     errx(1, "cx_nid_from_curve unsupported curve");

--- a/src/bolos/cx_ecpoint.c
+++ b/src/bolos/cx_ecpoint.c
@@ -291,6 +291,7 @@ cx_err_t sys_cx_ecpoint_scalarmul(cx_ecpoint_t *ec_P, const uint8_t *k,
   case CX_CURVE_SECP256K1:
   case CX_CURVE_SECP256R1:
   case CX_CURVE_SECP384R1:
+  case CX_CURVE_SECP521R1:
   case CX_CURVE_Stark256:
   case CX_CURVE_BrainPoolP256R1:
   case CX_CURVE_BrainPoolP256T1:


### PR DESCRIPTION
Secp521r1 curve was previously disabled because speculos or its dependencies did not support it.
Now that it's the case, this PR enables the support of secp521r1 curve.

I have tested it with nist and wycheproof test vectors for ECDH.