### PR TITLE
[fix] Doc theme 'rundocs/jekyll-rtd-theme' no longer exists

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Speculos documentation
 lang: en
 
-remote_theme: rundocs/jekyll-rtd-theme
+remote_theme: sighingnow/jekyll-gitbook
 
 exclude:
   - screenshot-btc-nanos.png


### PR DESCRIPTION
The theme was hosted [on GitHub here](https://github.com/rundocs/jekyll-rtd-theme). Both the repository and the organisation no longer exist, for at least 2 weeks.
So I changed the theme for now. Maybe we could switch back if it reappears some day (?)