### PR TITLE
Automatic GH pages DNS configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ author = 'Ledger'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['myst_parser']
+extensions = ['myst_parser', 'sphinxcontrib.rawfiles']
 
 templates_path = ['_templates']
 exclude_patterns = []
@@ -24,6 +24,7 @@ source_suffix = {
     '.md': 'markdown',
 }
 
+rawfiles = ['CNAME']
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-rtd-theme
 myst-parser
+sphinxcontrib-rawfiles


### PR DESCRIPTION
`CNAME` file is now included into the documentation build artifact, so that GH knows how to configure the DNS when it builds & deploys a new version of the Speculos documentation.