### PR TITLE
Enable the use of test key or prod key for PKI

### DIFF
--- a/speculos/main.py
+++ b/speculos/main.py
@@ -138,6 +138,9 @@ def run_qemu(s1: socket.socket, s2: socket.socket, args: argparse.Namespace, use
     else:
         argv += ['-k', str(args.sdk)]
 
+    if args.pki_prod:
+        argv += ['-p']
+
     # load cxlib only if available for the specified api level or sdk
     if args.apiLevel:
         cxlib_filepath = f"cxlib/{args.model}-api-level-cx-{args.apiLevel}.elf"
@@ -293,6 +296,7 @@ def main(prog=None) -> int:
                                                         "left button, 'a' right, 's' both). Default: arrow keys")
     group.add_argument('--progressive', action='store_true', help='Enable step-by-step rendering of graphical elements')
     group.add_argument('--zoom', help='Display pixel size.', type=int, choices=range(1, 11))
+    group.add_argument('-p', '--pki-prod', action='store_true', help='Use production public key for PKI')
 
     if prog:
         parser.prog = prog

--- a/src/bolos/os_signature.c
+++ b/src/bolos/os_signature.c
@@ -13,6 +13,19 @@ cx_ecfp_public_key_t const speculos_root_ca_public_key = {
          0xea, 0x66, 0xd8, 0x62, 0x28, 0xae, 0xe5, 0x93, 0x31, 0x72 }
 };
 
+cx_ecfp_public_key_t const root_ca_public_key = {
+  .curve = CX_CURVE_SECP256K1,
+  .W_len = 65,
+  .W = { 0x04, 0xf0, 0xe9, 0x52, 0x7c, 0xae, 0x72, 0x2a, 0xd3, 0x46, 0x15,
+         0x6f, 0x79, 0x9b, 0x89, 0x1c, 0x2c, 0x50, 0x3d, 0x88, 0x08, 0x92,
+         0xae, 0x3b, 0x91, 0x07, 0xae, 0xf2, 0x3c, 0x44, 0x2b, 0xb6, 0xe4,
+         0xc4, 0xe8, 0xe4, 0x70, 0xe3, 0xbb, 0x11, 0x46, 0xdb, 0x1c, 0x92,
+         0xed, 0x20, 0xae, 0xae, 0x47, 0xfc, 0x34, 0x80, 0x1d, 0x09, 0xad,
+         0xc3, 0x99, 0x28, 0xe1, 0xa1, 0xe9, 0x81, 0x4f, 0x5e, 0x95 }
+};
+
+bool pki_prod = false;
+
 cx_err_t cx_ecdsa_internal_init_public_key(cx_curve_t curve,
                                            const unsigned char *rawkey,
                                            unsigned int key_len,
@@ -156,8 +169,14 @@ bool os_ecdsa_verify_with_root_ca(uint8_t key_id, uint8_t *hash,
 {
   bool result = false;
   if (ROOT_CA_V3_KEY_ID == key_id) {
-    result = cx_ecdsa_internal_verify(&speculos_root_ca_public_key, hash,
-                                      hash_len, sig, sig_len);
+    if (pki_prod) {
+      result = cx_ecdsa_internal_verify(&root_ca_public_key, hash, hash_len,
+                                        sig, sig_len);
+    } else {
+      // Verification with test key
+      result = cx_ecdsa_internal_verify(&speculos_root_ca_public_key, hash,
+                                        hash_len, sig, sig_len);
+    }
   }
   return result;
 }

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -76,6 +76,7 @@ static size_t extra_rampage_size;
 sdk_version_t sdk_version = SDK_COUNT;
 hw_model_t hw_model = MODEL_COUNT;
 bool use_nbgl = false;
+extern bool pki_prod;
 
 static struct app_s *current_app;
 
@@ -714,7 +715,7 @@ int main(int argc, char *argv[])
 
   fprintf(stderr, "[*] speculos launcher revision: " GIT_REVISION "\n");
 
-  while ((opt = getopt(argc, argv, "c:tr:s:m:k:a:f:")) != -1) {
+  while ((opt = getopt(argc, argv, "c:tr:s:m:k:a:f:p")) != -1) {
     switch (opt) {
     case 'f':
       fonts_path = optarg;
@@ -754,6 +755,9 @@ int main(int argc, char *argv[])
       } else {
         errx(1, "invalid model \"%s\"", optarg);
       }
+      break;
+    case 'p':
+      pki_prod = true;
       break;
     default:
       usage(argv[0]);


### PR DESCRIPTION
This PR allows to either load a PKI production certificate or a test certificate for testing purposes. By default, speculos will verify the certificate with a test key, one has to launch speculos with the argument `--pki-prod/-p` to verify a production certificate. 