### PR TITLE
NVRAM data save and load support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] 2025-03-13
+
+### Added
+
+- `--save-nvram` and `--load-nvram` parameters that allow NVRAM testing
+- destination boundaries verification for `nvm_write()`
+
 ## [0.16.0] 2025-03-05
 
 ### Changed

--- a/src/bolos/default.c
+++ b/src/bolos/default.c
@@ -1,8 +1,10 @@
 #include <err.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <sys/mman.h>
 
 #include "emulate.h"
+#include "launcher.h"
 
 #define PAGE_SIZE 4096
 
@@ -13,8 +15,7 @@ unsigned long sys_os_global_pin_invalidate(void)
 }
 
 /*
- * TODO: ensure that source and destination address are valid.
- * TODO: map these data to the host filesystem.
+ * TODO: ensure that source address is valid.
  */
 int sys_nvm_write(void *dst_addr, void *src_addr, size_t src_len)
 {
@@ -22,6 +23,14 @@ int sys_nvm_write(void *dst_addr, void *src_addr, size_t src_len)
   size_t size;
   void *p;
 
+  /* Checking the destination boundaries */
+  unsigned long app_nvram_offset =
+      get_app_nvram_address() - get_app_text_load_addr();
+  if ((dst_addr < get_memory_code_address() + app_nvram_offset) ||
+      (dst_addr + src_len >=
+       get_memory_code_address() + app_nvram_offset + get_app_nvram_size())) {
+    errx(1, "App NVRAM write attempt out of boundaries\n");
+  }
   p = (void *)((unsigned long)dst_addr & (~(PAGE_SIZE - 1)));
   diff = (ptrdiff_t)dst_addr - (ptrdiff_t)p;
   size = src_len + diff;
@@ -38,6 +47,25 @@ int sys_nvm_write(void *dst_addr, void *src_addr, size_t src_len)
 
   if (mprotect(p, size, PROT_READ | PROT_EXEC) != 0) {
     err(1, "nvm_write: mprotect(PROT_READ | PROT_EXEC)");
+  }
+
+  if (get_app_save_nvram()) {
+    /* Writing data to host file */
+    FILE *fptr = fopen(get_app_nvram_file_name(), "r+");
+    if (fptr == NULL) {
+      fptr = fopen(get_app_nvram_file_name(), "w");
+      if (fptr == NULL) {
+        err(1, "Failed to open the app NVRAM file %s\n",
+            get_app_nvram_file_name());
+      }
+    }
+    unsigned long data_offset =
+        dst_addr - (get_memory_code_address() + app_nvram_offset);
+    fseek(fptr, data_offset, SEEK_SET);
+    if (fwrite(src_addr, 1, src_len, fptr) != src_len) {
+      errx(1, "App NVRAM write attempt failed\n");
+    }
+    fclose(fptr);
   }
 
   /* XXX: this function return void */

--- a/src/bolos/os.c
+++ b/src/bolos/os.c
@@ -4,6 +4,7 @@
 
 #include "emulate.h"
 #include "environment.h"
+#include "launcher.h"
 #include "svc.h"
 
 #define OS_SETTING_PLANEMODE_OLD 5

--- a/src/emulate.h
+++ b/src/emulate.h
@@ -23,8 +23,6 @@ typedef struct try_context_s try_context_t;
 typedef struct cx_ecfp_256_public_key_s cx_ecfp_public_key_t;
 typedef struct cx_ecfp_256_private_key_s cx_ecfp_private_key_t;
 
-struct app_s;
-
 #define SEPH_FILENO 0 /* 0 is stdin fileno */
 
 #ifndef UNUSED
@@ -123,13 +121,6 @@ unsigned long sys_io_seph_is_status_sent(void);
 unsigned long sys_io_seph_send(const uint8_t *buffer, uint16_t length);
 unsigned long sys_io_seph_recv(uint8_t *buffer, uint16_t maxlength,
                                unsigned int flags);
-
-void unload_running_app(bool unload_data);
-struct app_s *get_current_app(void);
-void save_current_context(struct sigcontext *sigcontext);
-void replace_current_context(struct sigcontext *sigcontext);
-int replace_current_code(struct app_s *app);
-int run_lib(char *name, unsigned long *parameters);
 
 unsigned long sys_try_context_set(try_context_t *context);
 unsigned long sys_try_context_get(void);

--- a/src/launcher.h
+++ b/src/launcher.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <signal.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+struct app_s;
+
+void unload_running_app(bool unload_data);
+void *get_memory_code_address(void);
+struct app_s *get_current_app(void);
+char *get_app_nvram_file_name(void);
+bool get_app_save_nvram(void);
+unsigned long get_app_nvram_address(void);
+unsigned long get_app_nvram_size(void);
+unsigned long get_app_text_load_addr(void);
+void save_current_context(struct sigcontext *sigcontext);
+void replace_current_context(struct sigcontext *sigcontext);
+int replace_current_code(struct app_s *app);
+int run_lib(char *name, unsigned long *parameters);

--- a/tests/c/syscalls/test_os_global_pin_is_validated.c
+++ b/tests/c/syscalls/test_os_global_pin_is_validated.c
@@ -22,9 +22,39 @@
 hw_model_t hw_model = MODEL_COUNT;
 sdk_version_t sdk_version = SDK_COUNT;
 
+void *get_memory_code_address(void)
+{
+  return NULL;
+}
+
 struct app_s *get_current_app(void)
 {
   return NULL;
+}
+
+char *get_app_nvram_file_name(void)
+{
+  return NULL;
+}
+
+bool get_app_save_nvram(void)
+{
+  return false;
+}
+
+unsigned long get_app_nvram_address(void)
+{
+  return 0;
+}
+
+unsigned long get_app_nvram_size(void)
+{
+  return 0;
+}
+
+unsigned long get_app_text_load_addr(void)
+{
+  return 0;
 }
 
 void unload_running_app(bool UNUSED(unload_data))


### PR DESCRIPTION
### Description
It makes a part of "App storage functionality simplification" project ( https://github.com/LedgerHQ/ledger-secure-sdk/pull/865). 
But it seems to me that this change is quite independent, does not break the current stuff and so can be already merged . Unless you have some objections. 

- [x] `--save-nvram`  input parameter is introduced that indicates that the NVRAM write have to be saved
- [x] `--load-nvram`  input parameter is introduced that indicates that a previously saved NVRAM data has to be loaded
- [x] the NVRAM data is saved to and pre-loaded from  `<name>_nvram.bin` (usually `main_nvram.bin`) host file
- [x]  a verification is performed for the write boundaries - not possible outside NVRAM zone defined in linker script 
- [x] tested with `app-boilerplate` locally built in 2 variants
    - [x] using only application storage functionality
    - [x] using also `N_` variables  <= everything is saved and loaded
- [x]  to test more locally:
    - [x] app-boilerplate@master (only `N_`)  - no impact
    - [x] tested locally with `app-exchange` and `pytest test/python/ --capture=tee-sys --tb=short -v --device stax -k "bitcoin and fund_valid_1` - no impact, no NVRAM calls. I do not know if any lib call in any app produces an nvm_write. 
- [x] the use in tests:
    - [x] https://github.com/LedgerHQ/app-boilerplate/blob/357d9eac92503843c6d55f84c5043a7ec53aabcd/tests/conftest.py#L24
    - [x] https://github.com/LedgerHQ/app-security-key/blob/6c19bf04a65bfcf23365739cffa25190c82ac00e/tests/functional/conftest.py#L149 