### PR TITLE
Activate the virtualenv instead of invoking its exec diretly

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -100,7 +100,7 @@ jobs:
         python3 -m venv venv-test
         ./venv-test/bin/pip install .
         ./venv-test/bin/speculos --help
-        echo "TAG_VERSION=$(python -c 'from speculos import __version__; print(__version__)')" >> "$GITHUB_ENV"
+        echo "TAG_VERSION=$(./venv-test/bin/python -c 'from speculos import __version__; print(__version__)')" >> "$GITHUB_ENV"
 
     - name: Build Speculos python package
       run: |


### PR DESCRIPTION
This will avoid that the last call uses system-wide packages