### PR TITLE
[ci][fix] Allow the CI to make a deployment

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -86,6 +86,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+      contents: write
     container:
       image: docker://ghcr.io/ledgerhq/speculos-builder:latest
 
@@ -168,11 +169,12 @@ jobs:
       if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
-        automatic_release_tag: "v${{ env.TAG_VERSION }}"
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: false
         files: |
-          LICENSE
+          COPYING
+          COPYING.LESSER
+          CHANGELOG.md
           dist/
 
   package_and_test_docker:


### PR DESCRIPTION
Made a mistake in the first version of this PR: the needed right is `contents` not `deployments`!

Doc reference [here](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions).