### PR TITLE
Fix BAGL applications calling NBGL libraries case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0] 2025-03-13
+## [0.17.0] 2025-03-14
 
 ### Added
 
 - `--save-nvram` and `--load-nvram` parameters that allow NVRAM testing
 - destination boundaries verification for `nvm_write()`
+- Make BAGL-based applications able to call NBGL-based libraries, or NBGL-based applications able to call BAGL-based libraries
 
 ## [0.16.0] 2025-03-05
 

--- a/speculos/mcu/display.py
+++ b/speculos/mcu/display.py
@@ -259,12 +259,13 @@ class Display(ABC):
         return self._display_args.rendering
 
     @property
-    def use_bagl(self) -> bool:
-        return self._display_args.use_bagl
+    @abstractmethod
+    def nbgl_gl(self) -> GraphicLibrary:
+        pass
 
     @property
     @abstractmethod
-    def gl(self) -> GraphicLibrary:
+    def bagl_gl(self) -> GraphicLibrary:
         pass
 
     @abstractmethod

--- a/speculos/mcu/headless.py
+++ b/speculos/mcu/headless.py
@@ -15,32 +15,32 @@ class Headless(Display):
         super().__init__(display, server)
 
         self.m = HeadlessPaintWidget(self.model, server.vnc)
-        self._gl: GraphicLibrary
-        if display.use_bagl:
-            self._gl = bagl.Bagl(self.m, MODELS[self.model].screen_size, self.model)
-        else:
-            self._gl = nbgl.NBGL(self.m, MODELS[self.model].screen_size, self.model)
+        self._bagl_gl: GraphicLibrary
+        self._nbgl_gl: GraphicLibrary
+        self._bagl_gl = bagl.Bagl(self.m, MODELS[self.model].screen_size, self.model)
+        self._nbgl_gl = nbgl.NBGL(self.m, MODELS[self.model].screen_size, self.model)
 
     @property
-    def gl(self) -> GraphicLibrary:
-        return self._gl
+    def bagl_gl(self):
+        return self._bagl_gl
+
+    @property
+    def nbgl_gl(self):
+        return self._nbgl_gl
 
     def display_status(self, data: bytes) -> List[TextEvent]:
-        assert isinstance(self.gl, bagl.Bagl)
-        ret = self.gl.display_status(data)
+        ret = self.bagl_gl.display_status(data)
         if MODELS[self.model].name == 'blue':
             self.screen_update()    # Actually, this method doesn't work
         return ret
 
     def display_raw_status(self, data: bytes) -> None:
-        assert isinstance(self.gl, bagl.Bagl)
-        self.gl.display_raw_status(data)
+        self.bagl_gl.display_raw_status(data)
         if MODELS[self.model].name == 'blue':
             self.screen_update()    # Actually, this method doesn't work
 
     def screen_update(self) -> bool:
-        assert isinstance(self.gl, bagl.Bagl)
-        return self.gl.refresh()
+        return self.bagl_gl.refresh()
 
 
 class HeadlessPaintWidget(FrameBuffer):

--- a/speculos/mcu/ocr.py
+++ b/speculos/mcu/ocr.py
@@ -122,11 +122,10 @@ class OCR:
     MAX_BLANK_SPACE_STAX = 24
     MAX_BLANK_SPACE_FLEX = 26
 
-    def __init__(self, model: str, use_bagl: bool):
+    def __init__(self, model: str):
         self.events: List[TextEvent] = []
         # Store the model of the device
         self.model = model
-        self.use_bagl = use_bagl
         # Maximum space for a letter to be considered part of the same word
         if model == "stax":
             self.max_blank_space = OCR.MAX_BLANK_SPACE_STAX
@@ -212,14 +211,14 @@ class OCR:
         # create a new TextEvent if there are no events yet or if there is a new line
         self.events.append(TextEvent(char, x, y, w, h, False))
 
-    def analyze_bitmap(self, data: bytes) -> None:
+    def analyze_bitmap(self, data: bytes, use_bagl: bool) -> None:
         """
         data contain information about the latest displayed bitmap.
         Since unified SDK, speculos added the displayed character to data.
         For older SKD versions, legacy behaviour is used: parsing internal
         fonts to find a matching bitmap.
         """
-        if not self.use_bagl:
+        if not use_bagl:
             # Can be called via SephTag.NBGL_DRAW_IMAGE or SephTag.NBGL_DRAW_IMAGE_RLE
             # In both cases, data contains:
             # - area (sizeof(nbgl_area_t))

--- a/speculos/mcu/screen.py
+++ b/speculos/mcu/screen.py
@@ -191,24 +191,27 @@ class Screen(Display):
     def __init__(self, display: DisplayArgs, server: ServerArgs) -> None:
         super().__init__(display, server)
         self.app: App
-        self._gl: GraphicLibrary
+        self._bagl_gl: GraphicLibrary
+        self._nbgl_gl: GraphicLibrary
 
     def set_app(self, app: App) -> None:
         self.app = app
         self.app.set_screen(self)
         model = self._display_args.model
-        if self.use_bagl:
-            self._gl = bagl.Bagl(app.widget, MODELS[model].screen_size, model)
-        else:
-            self._gl = nbgl.NBGL(app.widget, MODELS[model].screen_size, model)
+        self._bagl_gl = bagl.Bagl(app.widget, MODELS[model].screen_size, model)
+        self._nbgl_gl = nbgl.NBGL(app.widget, MODELS[model].screen_size, model)
 
     @property
     def m(self) -> QWidget:
         return self.app.widget
 
     @property
-    def gl(self):
-        return self._gl
+    def bagl_gl(self):
+        return self._bagl_gl
+
+    @property
+    def nbgl_gl(self):
+        return self._nbgl_gl
 
     def _key_event(self, event: QKeyEvent, pressed) -> None:
         key = Qt.Key(event.key())
@@ -223,20 +226,18 @@ class Screen(Display):
             self.app.close()
 
     def display_status(self, data: bytes) -> List[TextEvent]:
-        assert isinstance(self.gl, bagl.Bagl)
-        ret = self.gl.display_status(data)
+        ret = self.bagl_gl.display_status(data)
         if MODELS[self.model].name == 'blue':
             self.screen_update()    # Actually, this method doesn't work
         return ret
 
     def display_raw_status(self, data: bytes) -> None:
-        assert isinstance(self.gl, bagl.Bagl)
-        self.gl.display_raw_status(data)
+        self.bagl_gl.display_raw_status(data)
         if MODELS[self.model].name == 'blue':
             self.screen_update()    # Actually, this method doesn't work
 
     def screen_update(self) -> bool:
-        return self.gl.refresh()
+        return self.bagl_gl.refresh()
 
 
 class QtScreenNotifier(DisplayNotifier):

--- a/speculos/mcu/screen_text.py
+++ b/speculos/mcu/screen_text.py
@@ -105,10 +105,7 @@ class TextScreen(Display):
 
         self.width, self.height = MODELS[display_args.model].screen_size
         self.m = TextWidget(self, display_args.model)
-        if self.use_bagl:
-            self._gl = bagl.Bagl(self.m, MODELS[display_args.model].screen_size, display_args.model)
-        else:
-            raise NotImplementedError("This display can not emulate NBGL OS yet")
+        self._gl = bagl.Bagl(self.m, MODELS[display_args.model].screen_size, display_args.model)
 
         if display_args.keymap is not None:
             self.ARROW_KEYS = list(map(ord, display_args.keymap))

--- a/speculos/mcu/struct.py
+++ b/speculos/mcu/struct.py
@@ -32,7 +32,6 @@ class DisplayArgs:
     pixel_size: int
     x: Optional[int]
     y: Optional[int]
-    use_bagl: bool
 
 
 class ServerArgs(NamedTuple):

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -52,6 +52,7 @@ struct app_s {
   bool load_nvram;
   bool save_nvram;
   int fd;
+  bool use_nbgl;
   struct elf_info_s elf;
 };
 
@@ -84,7 +85,6 @@ static size_t extra_rampage_size;
 
 sdk_version_t sdk_version = SDK_COUNT;
 hw_model_t hw_model = MODEL_COUNT;
-bool use_nbgl = false;
 extern bool pki_prod;
 
 static struct app_s *current_app;
@@ -145,6 +145,7 @@ static int open_app(char *name, char *filename, struct elf_info_s *elf,
   apps[napp].save_nvram = save_nvram;
 
   apps[napp].fd = fd;
+  apps[napp].use_nbgl = (elf->fonts_addr == 0);
   apps[napp].elf.load_offset = elf->load_offset;
   apps[napp].elf.load_size = elf->load_size;
   apps[napp].elf.stack_addr = elf->stack_addr;
@@ -297,7 +298,7 @@ int replace_current_code(struct app_s *app)
 
   // Parse fonts and build bitmap -> character table
   parse_fonts(memory.code, app->elf.text_load_addr, app->elf.fonts_addr,
-              app->elf.fonts_size, use_nbgl);
+              app->elf.fonts_size, app->use_nbgl);
 
   return 0;
 }
@@ -530,7 +531,7 @@ static void *load_app(char *name)
 
   // Parse fonts and build bitmap -> character table
   parse_fonts(memory.code, app->elf.text_load_addr, app->elf.fonts_addr,
-              app->elf.fonts_size, use_nbgl);
+              app->elf.fonts_size, app->use_nbgl);
 
   return code;
 
@@ -983,7 +984,6 @@ int main(int argc, char *argv[])
     if (load_fonts(fonts_path) != 0) {
       return 1;
     }
-    use_nbgl = true;
   }
 
   if (setup_signals() != 0) {


### PR DESCRIPTION
The goal of this PR is to make BAGL-based applications able to call NBGL-based libraries, or NBGL-based applications able to call BAGL-based libraries.
It is especially important for Exchange (Swap) Application.
The main fix consist in supporting two instances of GraphicalLibrary (BAGL and NBGL), instead of a single one