### PR TITLE
Fixing Rust apps crash and adding Speculos Rust tests

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -186,6 +186,16 @@ jobs:
       test_dir: tests
       speculos_app_branch_name: ${{ github.ref }}
 
+  package_and_test_docker_rust:
+    name: Build and test the Speculos docker with a Rust app
+    uses: ./.github/workflows/reusable_ragger_tests_latest_speculos.yml
+    with:
+      app_repository: LedgerHQ/app-boilerplate-rust
+      app_branch_name: main
+      test_dir: tests
+      speculos_app_branch_name: ${{ github.ref }}
+      is_rust: true
+
   package_and_test_docker_for_nanos:
     name: Build and test the Speculos docker for Nano S
     uses: ./.github/workflows/reusable_ragger_tests_latest_speculos.yml

--- a/.github/workflows/reusable_ragger_tests_latest_speculos.yml
+++ b/.github/workflows/reusable_ragger_tests_latest_speculos.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: master
         type: string
+      is_rust:
+        description: '"true" if the app is using Rust SDK, else "false"'
+        required: false
+        default: false
+        type: string
 
 jobs:
   build_application:
@@ -27,6 +32,7 @@ jobs:
       app_repository: ${{ inputs.app_repository }}
       app_branch_name: ${{ inputs.app_branch_name }}
       upload_app_binaries_artifact: compiled_app_binaries-${{ inputs.app_branch_name }}
+      builder: ledger-app-builder
 
   build_docker_image:
     name: Build Speculos Docker image
@@ -109,9 +115,10 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: compiled_app_binaries-${{ inputs.app_branch_name }}
-        path: ${{ github.workspace }}/app/build
+        path: ${{ github.workspace }}/app/${{ inputs.is_rust == 'false' && 'build' || 'target' }}
 
-    - name: Run and test Speculos docker
+    - name: Run and test Speculos docker for C apps
+      if: ${{ inputs.is_rust == 'false' }}
       uses: addnab/docker-run-action@v3
       with:
         image: ledgerhq/speculos:test
@@ -120,3 +127,15 @@ jobs:
             apt-get update && apt-get install -y gcc
             pip install --extra-index-url https://test.pypi.org/simple/ -r /app/${{ inputs.test_dir }}/requirements.txt
             pytest /app/${{ inputs.test_dir }}/ --tb=short -v --device ${{ matrix.device }}
+
+    - name: Run and test Speculos docker for Rust apps
+      if: ${{ inputs.is_rust == 'true' }}
+      uses: addnab/docker-run-action@v3
+      with:
+        image: ledgerhq/speculos:test
+        options: -v ${{ github.workspace }}/app:/app
+        run: |
+            apt-get update && apt-get install -y gcc && apt-get install -y cargo
+            pip install --extra-index-url https://test.pypi.org/simple/ -r /app/${{ inputs.test_dir }}/requirements.txt
+            # test_version requires Cargo.toml
+            pytest /app/${{ inputs.test_dir }}/ --tb=short -v --device ${{ matrix.device }} -k "not test_version"


### PR DESCRIPTION
NVRAM data save and load functionality is not implemented yet for Rust apps.
It is not obvious to do it as the linking/relocation is rather different from the C one. 
So let's do the hotfix at first and avoid doing those operations and also NVRAM write access boundary checking for Rust apps. 

- [x] Rust apps crahs fixed
- [x]  `app-boilerplate-rust` build and test run using Speculos docker added

To follow-up Rust NVRAM save and load support for Rust apps: https://github.com/LedgerHQ/speculos/issues/562