### PR TITLE
Incorrect syscall address for 'os_endorsement_key1_sign_without…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.2] 2025-04-28
+
+### Fix
+
+- Incorrect syscall address for API level < 23
+
 ## [0.21.1] 2025-04-25
 
 ### Fix

--- a/sdk/bolos_syscalls_unified_sdk.h
+++ b/sdk/bolos_syscalls_unified_sdk.h
@@ -116,7 +116,7 @@
 #define SYSCALL_os_endorsement_key1_get_app_secret_ID_IN              0x01000058
 #define SYSCALL_os_endorsement_key1_sign_data_ID_IN                   0x03000059
 #define SYSCALL_os_endorsement_key2_derive_sign_data_ID_IN            0x0300005a
-#define SYSCALL_os_endorsement_key1_sign_without_code_hash_ID_IN      0x0400005b
+#define SYSCALL_os_endorsement_key1_sign_without_code_hash_ID_IN      0x0300005b
 // -- API_LEVEL_23 and above
 #define SYSCALL_ENDORSEMENT_get_code_hash_ID_IN                       0x01000055
 #define SYSCALL_ENDORSEMENT_get_public_key_ID_IN                      0x03000056


### PR DESCRIPTION
…_code_hash' on API level < 23