### PR TITLE
Fix missing check of API level 25 when loading fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] 2025-07-21
+
+### Fix
+
+- Fix missing check of API level 25 when loading fonts
+
 ## [0.25.0] 2025-07-16
 
 ### Added

--- a/src/bolos/fonts_info.c
+++ b/src/bolos/fonts_info.c
@@ -235,6 +235,7 @@ void parse_fonts(void *code, unsigned long text_load_addr,
   case SDK_API_LEVEL_22:
   case SDK_API_LEVEL_23:
   case SDK_API_LEVEL_24:
+  case SDK_API_LEVEL_25:
     break;
   default:
     // Unsupported API_LEVEL, will not parse fonts!


### PR DESCRIPTION
The goal of this PR is to fix missing check of API level 25 when loading fonts. The result was an issue with Ragger (no strings found)