### PR TITLE
Avoid defining strlcpy starting from glibc 2.38

### DIFF
--- a/src/bolos/io/mock/include/os_utils.h
+++ b/src/bolos/io/mock/include/os_utils.h
@@ -14,6 +14,10 @@ static inline void U2BE_ENCODE(uint8_t *buf, size_t off, uint32_t value)
   buf[off + 1] = value & 0xFF;
 }
 
+// strlcpy was added to glibc in version 2.38; this is a fallback implementation
+// only for previous versions
+#if !(defined(__GLIBC__) && defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 38))
+
 static inline size_t strlcpy(char *dst, const char *src, size_t size)
 {
   size_t srclen;
@@ -28,3 +32,5 @@ static inline size_t strlcpy(char *dst, const char *src, size_t size)
 
   return (srclen);
 }
+
+#endif


### PR DESCRIPTION
It was [added to the glibc](https://sourceware.org/git/?p=glibc.git;a=commit;h=454a20c8756c9c1d55419153255fc7692b3d2199), so the double definition causes a conflict on more recent versions.

Closes: #595 