### PR TITLE
Add 'libxcb-cursor0' dependency to Debian/Ubuntu installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo apt install \
     git cmake gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch \
     python3-pyqt6 python3-construct python3-flask-restful python3-jsonschema \
     python3-mnemonic python3-pil python3-pyelftools python3-requests \
-    qemu-user-static libvncserver-dev
+    qemu-user-static libvncserver-dev libxcb-cursor0
 
 # from the root directory of the source repository
 pip install .

--- a/docs/installation/build.md
+++ b/docs/installation/build.md
@@ -13,7 +13,7 @@ sudo apt install \
     git cmake gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gdb-multiarch \
     python3-pyqt6 python3-construct python3-flask-restful python3-jsonschema \
     python3-mnemonic python3-pil python3-pyelftools python3-requests \
-    qemu-user-static libvncserver-dev
+    qemu-user-static libvncserver-dev libxcb-cursor0
 ```
 
 Please note that VNC support (the `libvncserver-dev` package), although necessary


### PR DESCRIPTION
On a desktop computer with Ubuntu 25.04, speculos would crash at start until I installed this package.