### PR TITLE
README: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Speculos
 
 [![codecov](https://codecov.io/gh/LedgerHQ/speculos/branch/master/graph/badge.svg)](https://codecov.io/gh/LedgerHQ/speculos)
-[![lgtm](https://img.shields.io/lgtm/alerts/g/LedgerHQ/speculos.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/LedgerHQ/speculos/alerts/)
 
-![screenshot btc nano s](https://raw.githubusercontent.com/LedgerHQ/speculos/master/docs/screenshot-api-nanos-btc.png)
+![screenshot btc nano s](https://raw.githubusercontent.com/LedgerHQ/speculos/master/docs/_static/screenshot-api-nanos-btc.png)
 
 The goal of this project is to emulate Ledger Nano S+, Nano X, Apex+, Flex and Stax apps on
 standard desktop computers, without any hardware device. More information can


### PR DESCRIPTION
- LGTM's code quality badge is broken since LGTM.com was shut down in [december 2022](https://github.blog/news-insights/product-news/the-next-step-for-lgtm-com-github-code-scanning/#16th-of-december-lgtm-com-will-be-shut-down)
- Fix the API screenshot URL