### PR TITLE
Aligning everywhere python version to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN make -C build
 
 
 # Preparing final image
-FROM docker.io/library/python:3.9-slim
+FROM docker.io/library/python:3.10-slim
 
 ADD . /speculos
 WORKDIR /speculos

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ flask-cors = "*"
 pygame = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "154b210c7f8a5e7d7600991588500cf61b9282d3506228cc8bfc2f0ebcfe3a9c"
+            "sha256": "7d7e5e0c19f3aab5dff981c4ca87f172bfef7c89f232e612b6b7af7484538885"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.10"
         },
         "sources": [
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "construct>=2.10.56,<3.0.0",
     "flask>=2.0.0,<3.0.0",


### PR DESCRIPTION
As currently we've got some incoherence:
* `build.Dockerfile` used `docker.io/library/python:3.10-slim`, included by `Dockerfile` that in its turn included also `docker.io/library/python:3.9-slim` 
* in `Pipfile.lock`  it was requested `"python_version >= '3.10'",` for `click` package

All this ended up by omitting the `click` package in final Speculos docker image 