### PR TITLE
Fix derivation_path used when launching app with lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.11] 2025-12-05
+
+### Fix
+- Fix wrong derivation path when using libs (only use main app one)
+
 ## [0.25.10] 2025-12-04
 
 ### Added

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -215,8 +215,9 @@ unsigned long get_app_text_load_addr(void)
 
 unsigned long get_app_derivation_path(uint8_t **derivationPath)
 {
-  *derivationPath = current_app->elf.derivation_path;
-  return current_app->elf.derivation_path_len;
+  // use the derivation of the app, not libs
+  *derivationPath = apps[0].elf.derivation_path;
+  return apps[0].elf.derivation_path_len;
 }
 
 int replace_current_code(struct app_s *app)


### PR DESCRIPTION
The goal of this PR is to fix derivation_path used when launching app with lib (derivation_path used when launching app with lib