### PR TITLE
syscalls: Restore `os_registry_get_current_app_tag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.4] 2026-04-16
+
+### Changed
+
+- Restore `os_registry_get_current_app_tag` syscall
+
 ## [0.26.3] 2026-04-09
 
 ### Added

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -594,9 +594,8 @@ static int emulate_syscall_os(unsigned long syscall,
                               const unsigned long *parameters,
                               unsigned long *ret, bool verbose, int api_level)
 {
-  // code to remove when API LEVEL < 26 is not supported anymore
-  if ((api_level < 26) &&
-      (syscall == SYSCALL_os_registry_get_current_app_tag_ID_IN)) {
+  (void)api_level;
+  if (syscall == SYSCALL_os_registry_get_current_app_tag_ID_IN) {
     unsigned int tag = (unsigned int)parameters[0];
     uint8_t *buffer = (uint8_t *)parameters[1];
     size_t length = parameters[2];


### PR DESCRIPTION
The syscall is necessary in API LEVEL 26.
