### PR TITLE
Add Montgomery curves support to sys_cx_ecpoint_is_on_curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.6] 2026-04-23
+
+### Changed
+
+- Add Montgomery curves support to sys_cx_ecpoint_is_on_curve
+
 ## [0.26.5] 2026-04-22
 
 ### Changed

--- a/src/bolos/cx_ecpoint.c
+++ b/src/bolos/cx_ecpoint.c
@@ -703,6 +703,12 @@ cx_err_t sys_cx_ecpoint_is_on_curve(const cx_ecpoint_t *ec_P, bool *is_on_curve)
 
   CX_CHECK(cx_mpi_ecpoint_from_ecpoint(&P, ec_P));
 
+  if ((ec_P->curve == CX_CURVE_Curve25519) ||
+      (ec_P->curve == CX_CURVE_Curve448)) {
+    error = cx_montgomery_is_point_on_curve(&P, is_on_curve);
+    goto end;
+  }
+
   if ((nid = cx_nid_from_curve(ec_P->curve)) >= 0) {
     group = cx_group_from_nid_and_curve(nid, ec_P->curve);
   }

--- a/src/bolos/cx_montgomery.c
+++ b/src/bolos/cx_montgomery.c
@@ -252,3 +252,74 @@ end:
 
   return error;
 }
+
+cx_err_t cx_montgomery_is_point_on_curve(const cx_mpi_ecpoint_t *P,
+                                         bool *is_on_curve)
+{
+  cx_err_t error = CX_INTERNAL_ERROR;
+  cx_mpi_t *n, *a, *b, *x, *y, *r1, *r2, *r3;
+  cx_bn_t bn_n, bn_a, bn_b, bn_x, bn_y, bn_r1, bn_r2, bn_r3;
+  uint32_t sz;
+  const cx_curve_montgomery_t *domain;
+
+  domain = (const cx_curve_montgomery_t *)cx_ecdomain(P->curve);
+  if (domain == NULL) {
+    return CX_INVALID_PARAMETER;
+  }
+  if (cx_mpi_cmp_u32(P->z, 0) == 0) {
+    return CX_EC_INFINITE_POINT;
+  }
+  sz = domain->length;
+  bn_n = (cx_bn_t)(-1);
+  bn_a = (cx_bn_t)(-1);
+  bn_b = (cx_bn_t)(-1);
+  bn_x = (cx_bn_t)(-1);
+  bn_y = (cx_bn_t)(-1);
+  bn_r1 = (cx_bn_t)(-1);
+  bn_r2 = (cx_bn_t)(-1);
+  bn_r3 = (cx_bn_t)(-1);
+
+  n = cx_mpi_alloc_init(&bn_n, sz, domain->p, sz);
+  CX_CHECK(cx_mpi_check_memory_full(n));
+  a = cx_mpi_alloc(&bn_a, sz);
+  CX_CHECK(cx_mpi_check_memory_full(a));
+  b = cx_mpi_alloc(&bn_b, sz);
+  CX_CHECK(cx_mpi_check_memory_full(b));
+  x = cx_mpi_alloc(&bn_x, sz);
+  CX_CHECK(cx_mpi_check_memory_full(x));
+  y = cx_mpi_alloc(&bn_y, sz);
+  CX_CHECK(cx_mpi_check_memory_full(y));
+  r1 = cx_mpi_alloc(&bn_r1, sz);
+  CX_CHECK(cx_mpi_check_memory_full(r1));
+  r2 = cx_mpi_alloc(&bn_r2, sz);
+  CX_CHECK(cx_mpi_check_memory_full(r2));
+  r3 = cx_mpi_alloc(&bn_r3, sz);
+  CX_CHECK(cx_mpi_check_memory_full(r3));
+
+  CX_CHECK(cx_mpi_init(a, domain->a, sz));
+  CX_CHECK(cx_mpi_init(b, domain->b, sz));
+  CX_CHECK(cx_mpi_copy(x, P->x));
+  CX_CHECK(cx_mpi_copy(y, P->y));
+  CX_CHECK(cx_mpi_mod_mul(r1, x, x, n));
+  CX_CHECK(cx_mpi_mod_mul(r2, y, y, n));
+  CX_CHECK(cx_mpi_mod_mul(r3, r2, b, n)); // r3 = b*r2 = b*y^2
+  CX_CHECK(cx_mpi_mod_mul(b, r1, x, n));  // b = r1*x = x^2*x = x^3
+  CX_CHECK(cx_mpi_mod_mul(r2, r1, a, n)); // r2 = a*r1 = a*x^2
+  CX_CHECK(cx_mpi_mod_add(a, r2, x, n));  // a = r2+x = a*x^2+x
+  CX_CHECK(cx_mpi_mod_add(r2, a, b, n));  // r2 = b+a = x^3+a*x^2+x
+  CX_CHECK(cx_mpi_mod_sub(a, r2, r3, n));
+
+  *is_on_curve = (cx_mpi_cmp_u32(a, 0) == 0); // b*y^2 == x^3+a*x^2+x
+
+end:
+  cx_mpi_destroy(&bn_n);
+  cx_mpi_destroy(&bn_a);
+  cx_mpi_destroy(&bn_b);
+  cx_mpi_destroy(&bn_x);
+  cx_mpi_destroy(&bn_y);
+  cx_mpi_destroy(&bn_r1);
+  cx_mpi_destroy(&bn_r2);
+  cx_mpi_destroy(&bn_r3);
+
+  return error;
+}

--- a/src/bolos/cx_mpi.c
+++ b/src/bolos/cx_mpi.c
@@ -1202,3 +1202,11 @@ void cx_mpi_swap(cx_mpi_t *a, cx_mpi_t *b, const int c)
     BN_swap(a, b);
   }
 }
+
+cx_err_t cx_mpi_check_memory_full(cx_mpi_t *x)
+{
+  if (x == NULL) {
+    return CX_MEMORY_FULL;
+  }
+  return CX_OK;
+}

--- a/src/bolos/cxlib.h
+++ b/src/bolos/cxlib.h
@@ -152,6 +152,7 @@ cx_err_t cx_mpi_gf2_n_mul(cx_mpi_t *r, const cx_mpi_t *a, const cx_mpi_t *b,
                           const cx_mpi_t *n, const cx_mpi_t *h);
 void cx_mpi_reverse(cx_mpi_t *x, uint32_t nbytes);
 void cx_mpi_swap(cx_mpi_t *a, cx_mpi_t *b, const int c);
+cx_err_t cx_mpi_check_memory_full(cx_mpi_t *x);
 
 cx_err_t cx_mpi_ecpoint_normalize(cx_mpi_ecpoint_t *P);
 ;
@@ -255,6 +256,8 @@ cx_err_t cx_montgomery_recover_y(cx_mpi_ecpoint_t *P, uint32_t sign);
 
 cx_err_t cx_montgomery_mul_coordinate(cx_curve_t curve, cx_mpi_t *u_coordinate,
                                       const uint8_t *scalar, size_t scalar_len);
+cx_err_t cx_montgomery_is_point_on_curve(const cx_mpi_ecpoint_t *P,
+                                         bool *is_on_curve);
 
 // cx_ecpoint.c
 cx_err_t cx_mpi_ecpoint_from_ecpoint(cx_mpi_ecpoint_t *P,


### PR DESCRIPTION
This PR enables Curve25519 and Curve448 with sys_cx_ecpoint_is_on_curve. This is necessary to perform an ECDH with these curves.