### PR TITLE
NBGL deserialization: Ignore text after page separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.7] 2026-05-04
+
+### Changed
+
+- Fix an issue with TextEvent and NBGL deserialization, when a string contains a page break separator.
+
 ## [0.26.6] 2026-04-23
 
 ### Changed

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -479,6 +479,10 @@ class SeProxyHal(IODevice):
             if 'obj' in d:
                 content = d['obj']['content']
                 text = content.get('text', '')
+
+                # Delete all content after page break ('\f')
+                text = text.split('\f')[0]
+
                 if len(text) > 0:
                     # Text may be split in lines
                     lines = text.split('\n')


### PR DESCRIPTION
When deserialize NBGL objects, ignore text after the '\f' page break separator. Those text are not actually displayed - they are displayed on the next pages.