### PR TITLE
Add endorsement syscall

### DIFF
--- a/src/bolos/endorsement.c
+++ b/src/bolos/endorsement.c
@@ -305,9 +305,10 @@ bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_DATA(uint8_t *data, size_t data_length,
   return ret;
 }
 
-bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH(
-    uint8_t *data, size_t data_length, uint8_t *out_signature,
-    size_t *out_signature_length)
+bolos_err_t
+sys_ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH(uint8_t *data, size_t data_length,
+                                            uint8_t *out_signature,
+                                            size_t *out_signature_length)
 {
   uint32_t tmp_len = *out_signature_length;
   bolos_err_t ret = sys_ENDORSEMENT_key1_sign_without_code_hash(

--- a/src/bolos/endorsement.c
+++ b/src/bolos/endorsement.c
@@ -305,6 +305,17 @@ bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_DATA(uint8_t *data, size_t data_length,
   return ret;
 }
 
+bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH(
+    uint8_t *data, size_t data_length, uint8_t *out_signature,
+    size_t *out_signature_length)
+{
+  uint32_t tmp_len = *out_signature_length;
+  bolos_err_t ret = sys_ENDORSEMENT_key1_sign_without_code_hash(
+      data, data_length, out_signature, &tmp_len);
+  *out_signature_length = tmp_len;
+  return ret;
+}
+
 bolos_err_t sys_ENDORSEMENT_GET_CODE_HASH(uint8_t *out_hash, size_t hash_length)
 {
   if (!out_hash || (hash_length < ENDORSEMENT_HASH_LENGTH)) {

--- a/src/bolos/endorsement.h
+++ b/src/bolos/endorsement.h
@@ -94,6 +94,10 @@ bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_DATA(uint8_t *data, size_t data_length,
                                            uint8_t *out_signature,
                                            size_t *out_signature_length);
 
+bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH(
+    uint8_t *data, size_t data_length, uint8_t *out_signature,
+    size_t *out_signature_length);
+
 bolos_err_t sys_ENDORSEMENT_GET_CODE_HASH(uint8_t *out_hash,
                                           size_t hash_length);
 

--- a/src/bolos/endorsement.h
+++ b/src/bolos/endorsement.h
@@ -94,9 +94,10 @@ bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_DATA(uint8_t *data, size_t data_length,
                                            uint8_t *out_signature,
                                            size_t *out_signature_length);
 
-bolos_err_t sys_ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH(
-    uint8_t *data, size_t data_length, uint8_t *out_signature,
-    size_t *out_signature_length);
+bolos_err_t
+sys_ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH(uint8_t *data, size_t data_length,
+                                            uint8_t *out_signature,
+                                            size_t *out_signature_length);
 
 bolos_err_t sys_ENDORSEMENT_GET_CODE_HASH(uint8_t *out_hash,
                                           size_t hash_length);

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -875,6 +875,12 @@ emulate_syscall_endorsement_pre_api_level_26(unsigned long syscall,
                   uint8_t *, out_signature,
                   uint32_t *, out_signature_length);
 
+        SYSCALL4(ENDORSEMENT_key1_sign_without_code_hash, "(%p, %u, %p, %p)",
+                  uint8_t *, data,
+                  uint32_t, data_length,
+                  uint8_t *, out_signature,
+                  uint32_t *, out_signature_length);
+
         SYSCALL1(ENDORSEMENT_get_code_hash, "(%p)",
                   uint8_t *, out_hash);
 
@@ -904,6 +910,12 @@ emulate_syscall_endorsement_post_api_level_25(unsigned long syscall,
                   size_t *, out_public_key_length)
 
         SYSCALL4(ENDORSEMENT_KEY1_SIGN_DATA, "(%p, %u, %p, %p)",
+                  uint8_t *, data,
+                  size_t, data_length,
+                  uint8_t *, out_signature,
+                  size_t *, out_signature_length)
+
+        SYSCALL4(ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH, "(%p, %u, %p, %p)",
                   uint8_t *, data,
                   size_t, data_length,
                   uint8_t *, out_signature,


### PR DESCRIPTION
This PR adds the missing implementation of the syscall ENDORSEMENT_KEY1_SIGN_WITHOUT_CODE_HASH.