### PR TITLE
docs: drop the redundant CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-speculos.ledger.com

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ author = "Ledger"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_parser", "sphinxcontrib.rawfiles"]
+extensions = ["myst_parser"]
 
 templates_path = ["_templates"]
 # requirements.txt would otherwise be picked up as a Markdown document (see the
@@ -25,8 +25,6 @@ source_suffix = {
     ".txt": "markdown",
     ".md": "markdown",
 }
-
-rawfiles = ["CNAME"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,3 @@ sphinx<7
 # rtd-theme v3 is still beta but should work with newer sphinx versions
 sphinx-rtd-theme<=2
 myst-parser
-sphinxcontrib-rawfiles


### PR DESCRIPTION
The speculos.ledger.com custom domain is pinned server-side in the repo Pages settings. With the official GitHub Pages Action the domain no longer needs a CNAME file embedded in the build artifact.

Remove docs/CNAME and the sphinxcontrib.rawfiles extension that only existed to copy it into the HTML output.