### PR TITLE
fix(seproxyhal): don't crash on invalid UTF-8 in NBGL text lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation: refreshed outdated macOS, Docker, usage and clients pages (removed obsolete `--model nanos`, missing `btc.elf`, manual Dockerfile edits, archived `btchip-python` references, and the obsolete `ledgerblue` version pin)
 - `docker-compose.yml`: use the bundled `apps/boil.elf` and a valid default configuration
 
+### Fixed
+
+- Don't crash on NBGL text lines containing invalid UTF-8 (sent by apps rendering non-NUL-terminated strings); replace the undecodable bytes and log a warning instead
+
 ## [0.26.9] 2026-06-17
 
 ### Fixed

--- a/speculos/mcu/seproxyhal.py
+++ b/speculos/mcu/seproxyhal.py
@@ -393,8 +393,15 @@ class SeProxyHal(IODevice):
 
         elif tag == SephTag.NBGL_SEND_SPECULOS_TEXT_LINE:
             self.nbgl_speculos_text_lines_enabled = True
-            # Extract text content
-            text = data[:-8].decode()
+            # Extract text content. The text is controlled by the app and may
+            # contain invalid UTF-8 (e.g. a buggy app rendering a
+            # non-NUL-terminated string sends trailing garbage bytes): replace
+            # undecodable bytes instead of crashing speculos.
+            try:
+                text = data[:-8].decode("utf-8")
+            except UnicodeDecodeError:
+                self.logger.warning(f"invalid UTF-8 in NBGL text line: {data[:-8]!r}")
+                text = data[:-8].decode("utf-8", errors="replace")
             # Extract coordinates
             coordinates = data[-8:]
             x, y, w, h = struct.unpack('>4H', coordinates)

--- a/tests/python/mcu/test_seproxyhal.py
+++ b/tests/python/mcu/test_seproxyhal.py
@@ -1,0 +1,56 @@
+import socket
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+from speculos.mcu.seproxyhal import SeProxyHal, SephTag
+
+
+@pytest.fixture
+def seph():
+    """A SeProxyHal instance connected to a socketpair standing in for the app."""
+    seph_sock, app_sock = socket.socketpair()
+    seph = SeProxyHal(seph_sock, model="stax")
+    yield seph, app_sock
+    app_sock.close()
+    seph_sock.close()
+
+
+def send_seph_packet(app_sock: socket.socket, tag: SephTag, data: bytes) -> None:
+    """Send a raw seproxyhal packet, as the app under emulation would."""
+    packet = tag.to_bytes(1, "big") + len(data).to_bytes(2, "big") + data
+    app_sock.sendall(packet)
+
+
+class TestSeProxyHal:
+    @staticmethod
+    def send_text_line(seph: SeProxyHal, app_sock: socket.socket, text: bytes,
+                       x: int = 10, y: int = 20, w: int = 30, h: int = 40) -> None:
+        data = text + struct.pack(">4H", x, y, w, h)
+        send_seph_packet(app_sock, SephTag.NBGL_SEND_SPECULOS_TEXT_LINE, data)
+        seph.can_read(MagicMock())
+
+    def test_nbgl_text_line(self, seph):
+        seph, app_sock = seph
+        self.send_text_line(seph, app_sock, "Address".encode("utf-8"))
+
+        events = seph.ocr.get_events()
+        assert len(events) == 1
+        assert events[0].text == "Address"
+        assert (events[0].x, events[0].y, events[0].w, events[0].h) == (10, 20, 30, 40)
+
+    def test_nbgl_text_line_invalid_utf8(self, seph):
+        """
+        An app displaying a string which isn't valid UTF-8 (e.g. a
+        non-NUL-terminated string followed by garbage stack bytes, as rendered
+        by app-bitcoin-new 2.4.6) must not crash speculos: undecodable bytes
+        are replaced and the text is still forwarded to the OCR/automation
+        layer.
+        """
+        seph, app_sock = seph
+        self.send_text_line(seph, app_sock, b"Wallet id @: tpsze\xd1\x65\x91\x8f")
+
+        events = seph.ocr.get_events()
+        assert len(events) == 1
+        assert events[0].text == "Wallet id @: tpsze�e��"


### PR DESCRIPTION
Disclaimer: entirely vibe-coded, feel free to close if it makes no sense.

The NBGL_SEND_SPECULOS_TEXT_LINE (0x5A) handler decoded the app-provided text with strict UTF-8, so a single invalid byte killed speculos entirely:

    File ".../speculos/mcu/seproxyhal.py", line 397, in can_read
        text = data[:-8].decode()
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd1 in
    position 20: invalid continuation byte
    speculos: Stopping Speculos

This was hit in the wild by app-bitcoin-new 2.4.6, whose register-wallet screen renders a non-NUL-terminated string, so the packet contains trailing uninitialized stack bytes (e.g. b"\xd1\x65\x91\x8f"). In CI the crash cascades into unrelated failures, as every subsequent request gets "Connection refused". (A fix for the app is being submitted separately.)

A buggy app should produce garbled automation text, not kill the emulator: decode with errors="replace" and log a warning containing the raw bytes, so the offending app bug remains diagnosable.

Add a unit test feeding a raw 0x5A packet with invalid UTF-8 through SeProxyHal.can_read(), asserting the OCR layer receives the replaced text instead of speculos raising UnicodeDecodeError.