### PR TITLE
Web interface: tap and swipe support for touchscreen models (Stax/Flex/Apex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Web interface: touchscreen support for Stax/Flex/Apex models. Clicking the
+  screen sends a tap, dragging sends a swipe (through the existing `/finger`
+  API); the physical-button controls are hidden on touchscreen models.
+- New `GET /model` API endpoint returning the device model name and screen size.
+
 ## [0.26.10] 2026-06-17
 
 ### Added

--- a/speculos/api/api.py
+++ b/speculos/api/api.py
@@ -16,6 +16,7 @@ from .automation import Automation
 from .button import Button
 from .events import Events
 from .finger import Finger
+from .model import ModelInfo
 from .screenshot import Screenshot
 from .swagger import Swagger
 from .web_interface import WebInterface
@@ -84,6 +85,7 @@ class ApiWrapper:
                                resource_class_kwargs=seph_kwargs)
         self._api.add_resource(Events, "/events", resource_class_kwargs=event_kwargs)
         self._api.add_resource(Finger, "/finger", resource_class_kwargs=seph_kwargs)
+        self._api.add_resource(ModelInfo, "/model", resource_class_kwargs=screen_kwargs)
         self._api.add_resource(Screenshot, "/screenshot", resource_class_kwargs=screen_kwargs)
         self._api.add_resource(Swagger, "/swagger/", resource_class_kwargs=app_kwargs)
         self._api.add_resource(WebInterface, "/", resource_class_kwargs=app_kwargs)

--- a/speculos/api/model.py
+++ b/speculos/api/model.py
@@ -1,0 +1,9 @@
+from ..mcu.struct import MODELS
+from .restful import ScreenResource
+
+
+class ModelInfo(ScreenResource):
+    def get(self):
+        model = self.screen.display.model
+        width, height = MODELS[model].screen_size
+        return {"name": model, "screen": {"width": width, "height": height}}, 200

--- a/speculos/api/static/index.html
+++ b/speculos/api/static/index.html
@@ -253,8 +253,13 @@ function on_keydown(e) {
 
 function zoom_screenshot() {
   var element = document.getElementById("screenshot");
-  element.width = element.naturalWidth * 2;
-  element.height = element.naturalHeight * 2;
+  element.addEventListener("load", function () {
+    // The 2x zoom suits the small Nano screens; the larger touchscreen
+    // models (400x672 and up) are displayed at natural size.
+    var zoom = (element.naturalWidth <= 200) ? 2 : 1;
+    element.width = element.naturalWidth * zoom;
+    element.height = element.naturalHeight * zoom;
+  });
 }
 
 /*

--- a/speculos/api/static/index.html
+++ b/speculos/api/static/index.html
@@ -100,6 +100,11 @@ body.dark-mode a {
   padding-top: 10px;
 }
 
+.touch-hint {
+  color: #888;
+  font-size: 0.9em;
+}
+
 .send-apdu {
   text-align: left;
   width: 100%;
@@ -151,6 +156,9 @@ body.dark-mode .footer {
     <script>
 "use strict";
 
+// Whether the emulated device uses a touchscreen instead of physical buttons.
+var g_touch_device = false;
+
 function post_request(url, data, callback) {
   var http = new XMLHttpRequest();
   http.open("POST", url, true);
@@ -161,6 +169,17 @@ function post_request(url, data, callback) {
     }
   }
   http.send(JSON.stringify(data));
+}
+
+function get_request(url, callback) {
+  var http = new XMLHttpRequest();
+  http.open("GET", url, true);
+  http.onreadystatechange = function() {
+    if (http.readyState == 4 && http.status == 200) {
+      callback(http);
+    }
+  }
+  http.send();
 }
 
 function click_button(button) {
@@ -217,15 +236,17 @@ function on_keydown(e) {
       send_apdu();
     }
   } else {
-    // Only send buttons when the APDU input does not have the focus
-    if (e.code == "ArrowDown" || e.keyCode == 40) {
-      click_button("both");
-    } else if (e.code == "ArrowLeft" || e.keyCode == 37) {
-      click_button("left");
-    } else if (e.code == "ArrowRight" || e.keyCode == 39) {
-      click_button("right");
-    } else if (e.code == "KeyD" || e.keyCode == 68) {
+    if (e.code == "KeyD" || e.keyCode == 68) {
       document.body.classList.toggle("dark-mode");
+    } else if (!g_touch_device) {
+      // Only send buttons when the APDU input does not have the focus
+      if (e.code == "ArrowDown" || e.keyCode == 40) {
+        click_button("both");
+      } else if (e.code == "ArrowLeft" || e.keyCode == 37) {
+        click_button("left");
+      } else if (e.code == "ArrowRight" || e.keyCode == 39) {
+        click_button("right");
+      }
     }
   }
 }
@@ -236,11 +257,70 @@ function zoom_screenshot() {
   element.height = element.naturalHeight * 2;
 }
 
+/*
+ * Touchscreen support (Stax, Flex, Apex): forward clicks on the screenshot to
+ * the /finger endpoint. A click is a tap; a drag is a swipe (press at the
+ * start position, release at the end position).
+ */
+function setup_touch(screen_width, screen_height) {
+  var element = document.getElementById("screenshot");
+  var start = null;
+
+  g_touch_device = true;
+
+  // A tap and a very short drag should be equivalent: below this distance
+  // (in screen pixels), the gesture is sent as a single-position touch.
+  var SWIPE_THRESHOLD = 5;
+
+  function to_screen_coords(event) {
+    var rect = element.getBoundingClientRect();
+    var x = Math.round((event.clientX - rect.left) * screen_width / rect.width);
+    var y = Math.round((event.clientY - rect.top) * screen_height / rect.height);
+    x = Math.min(Math.max(x, 0), screen_width - 1);
+    y = Math.min(Math.max(y, 0), screen_height - 1);
+    return [x, y];
+  }
+
+  // Replace the physical buttons: touch devices have none.
+  var buttons = document.getElementsByClassName("buttons")[0];
+  buttons.textContent = "click = tap, drag = swipe";
+  buttons.className += " touch-hint";
+  element.style.cursor = "pointer";
+  // Dragging must swipe, not drag the image itself.
+  element.ondragstart = function (e) { e.preventDefault(); };
+
+  element.addEventListener("mousedown", function (e) {
+    if (e.button == 0) {
+      start = to_screen_coords(e);
+    }
+  });
+  document.addEventListener("mouseup", function (e) {
+    if (start === null || e.button != 0) {
+      return;
+    }
+    var end = to_screen_coords(e);
+    var data = {"action": "press-and-release", "x": start[0], "y": start[1]};
+    if (Math.abs(end[0] - start[0]) > SWIPE_THRESHOLD || Math.abs(end[1] - start[1]) > SWIPE_THRESHOLD) {
+      data["x2"] = end[0];
+      data["y2"] = end[1];
+    }
+    start = null;
+    post_request("/finger", data, null);
+  });
+}
+
 function main() {
   zoom_screenshot();
   refresh_screen();
   stream_events();
   document.onkeydown = on_keydown;
+  get_request("/model", function (http) {
+    var model = JSON.parse(http.responseText);
+    // Every non-Nano model is a touchscreen without physical buttons.
+    if (model["name"].indexOf("nano") == -1) {
+      setup_touch(model["screen"]["width"], model["screen"]["height"]);
+    }
+  });
 }
     </script>
   </head>

--- a/speculos/api/static/swagger/swagger.json
+++ b/speculos/api/static/swagger/swagger.json
@@ -308,6 +308,42 @@
         }
       }
     },
+    "/model": {
+      "get": {
+        "summary": "Get the device model and screen size",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "example": "flex"
+                    },
+                    "screen": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "integer",
+                          "example": 480
+                        },
+                        "height": {
+                          "type": "integer",
+                          "example": 600
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/screenshot": {
       "get": {
         "summary": "Get a screenshot",

--- a/speculos/api/swagger.yaml
+++ b/speculos/api/swagger.yaml
@@ -131,6 +131,30 @@ paths:
         "400":
           description: "invalid parameter"
 
+  /model:
+    get:
+      summary: "Get the device model and screen size"
+      responses:
+        "200":
+          description: "successful operation"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    example: "flex"
+                  screen:
+                    type: object
+                    properties:
+                      width:
+                        type: integer
+                        example: 480
+                      height:
+                        type: integer
+                        example: 600
+
   /screenshot:
     get:
       summary: "Get a screenshot"

--- a/tests/python/api/test_api.py
+++ b/tests/python/api/test_api.py
@@ -8,6 +8,7 @@ import time
 from collections import namedtuple
 
 from speculos.client import SpeculosClient
+from speculos.mcu.struct import MODELS
 
 API_URL = "http://127.0.0.1:5000"
 
@@ -49,6 +50,14 @@ class TestApi:
         data = json.dumps({"x": 0, "y": 0, "action": "press-and-release"}).encode()
         with requests.post(f"{API_URL}/finger", data=data) as response:
             assert response.status_code == 200
+
+    def test_model(self, app):
+        with requests.get(f"{API_URL}/model") as response:
+            assert response.status_code == 200
+            data = response.json()
+            assert data["name"] == app.model
+            width, height = MODELS[app.model].screen_size
+            assert data["screen"] == {"width": width, "height": height}
 
     def test_events(self):
         """


### PR DESCRIPTION
## Problem

The web interface only exposes the Nano physical buttons (`left`/`both`/`right`). On touchscreen models (Stax, Flex, Apex) clicking the rendered screen does nothing, so the page is effectively view-only, even though the `/finger` API supports taps and swipes.

## Changes

- **New `GET /model` endpoint** returning the device model name and screen size (`{"name": "flex", "screen": {"width": 480, "height": 600}}`), so clients and the web UI can adapt without out-of-band knowledge. Documented in both swagger files, covered by a new API test.
- **Web UI touch support**: on touchscreen models, clicking the screenshot sends a tap and dragging sends a swipe (single `press-and-release` call with `x2`/`y2`), with coordinates mapped through `getBoundingClientRect` (correct at any zoom) and clamped to screen bounds. Drags shorter than 5 px count as taps.
- On touchscreen models the button row is replaced by a short hint (`click = tap, drag = swipe`) and the arrow-key button shortcuts are disabled. Nano models are strictly unchanged.
- Vanilla JS matching the existing page style; no new dependency. If `/model` is unavailable (older core), the page silently keeps its previous behavior.

## Testing

- Flex (API_LEVEL_26 app in Speculos): tapped through several NBGL flows (home → info, choice pages) from the web page; verified emitted `/finger` payloads for tap, swipe (`x2`/`y2` present), sub-threshold drag (no `x2`), and out-of-image drag (clamped to `0..width-1`).
- Nano X (`apps/nanox#boil#2.1.0.elf`): buttons and keyboard shortcuts unchanged, screen clicks send nothing, `/model` returns `128x64`.
- `tests/python/api`: `test_model`, `test_finger`, `test_button` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)